### PR TITLE
chore: rename package from browser-automation-mcp-server to athena-browser-mcp

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -163,7 +163,7 @@ jobs:
         run: |
           echo "🎉 Release ${{ needs.validate.outputs.tag }} published successfully!"
           echo ""
-          echo "📦 NPM Package: https://www.npmjs.com/package/browser-automation-mcp-server/v/${{ needs.validate.outputs.version }}"
+          echo "📦 NPM Package: https://www.npmjs.com/package/athena-browser-mcp/v/${{ needs.validate.outputs.version }}"
           echo "🔖 GitHub Release: ${{ github.server_url }}/${{ github.repository }}/releases/tag/${{ needs.validate.outputs.tag }}"
           echo ""
-          echo "Install with: npm install browser-automation-mcp-server@${{ needs.validate.outputs.version }}"
+          echo "Install with: npm install athena-browser-mcp@${{ needs.validate.outputs.version }}"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Browser Automation MCP Server
 
 [![CI](https://github.com/lespaceman/athena-browser-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/lespaceman/athena-browser-mcp/actions/workflows/ci.yml)
-[![npm version](https://badge.fury.io/js/browser-automation-mcp-server.svg)](https://www.npmjs.com/package/browser-automation-mcp-server)
+[![npm version](https://badge.fury.io/js/athena-browser-mcp.svg)](https://www.npmjs.com/package/athena-browser-mcp)
 [![codecov](https://codecov.io/gh/lespaceman/athena-browser-mcp/branch/main/graph/badge.svg)](https://codecov.io/gh/lespaceman/athena-browser-mcp)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
@@ -89,7 +89,7 @@ Add to your Claude Desktop config file:
   "mcpServers": {
     "browser-automation": {
       "command": "node",
-      "args": ["/path/to/browser-automation-mcp-server/dist/browser-automation-mcp-server.js"],
+      "args": ["/path/to/athena-browser-mcp/dist/src/index.js"],
       "env": {
         "CEF_BRIDGE_HOST": "localhost",
         "CEF_BRIDGE_PORT": "9222",
@@ -305,7 +305,7 @@ npm test
 Enable debug logging:
 
 ```bash
-DEBUG=mcp:* node dist/browser-automation-mcp-server.js
+DEBUG=mcp:* node dist/src/index.js
 ```
 
 Check MCP communication:
@@ -317,9 +317,14 @@ tail -f ~/Library/Logs/Claude/mcp*.log  # macOS
 
 ## API Reference
 
-See [browser-automation-mcp-tools.json](./browser-automation-mcp-tools.json) for complete tool definitions.
+See [src/config/tools.json](./src/config/tools.json) for complete tool definitions.
 
-See [browser-automation-mcp-types.ts](./browser-automation-mcp-types.ts) for TypeScript type definitions.
+See type definitions in:
+
+- [src/domains/interaction/interaction.types.ts](./src/domains/interaction/interaction.types.ts)
+- [src/domains/perception/perception.types.ts](./src/domains/perception/perception.types.ts)
+- [src/domains/navigation/navigation.types.ts](./src/domains/navigation/navigation.types.ts)
+- [src/domains/session/session.types.ts](./src/domains/session/session.types.ts)
 
 ## Design Principles
 
@@ -332,9 +337,9 @@ See [browser-automation-mcp-types.ts](./browser-automation-mcp-types.ts) for Typ
 
 ## Contributing
 
-1. Add new tools to `browser-automation-mcp-tools.json`
-2. Add type definitions to `browser-automation-mcp-types.ts`
-3. Implement handlers in `browser-automation-mcp-server.ts`
+1. Add new tools to `src/config/tools.json`
+2. Add type definitions to appropriate domain type files
+3. Implement handlers in respective domain handler files
 4. Add tests in `tests/`
 5. Update README with examples
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing Guide
 
-This document describes how to release new versions of `browser-automation-mcp-server` to npm.
+This document describes how to release new versions of `athena-browser-mcp` to npm.
 
 ## Prerequisites
 
@@ -152,11 +152,11 @@ The workflow will:
 
 After the release workflow completes:
 
-1. Check npm package page: https://www.npmjs.com/package/browser-automation-mcp-server
+1. Check npm package page: https://www.npmjs.com/package/athena-browser-mcp
 2. Verify the new version is listed
 3. Test installation:
    ```bash
-   npm install browser-automation-mcp-server@latest
+   npm install athena-browser-mcp@latest
    ```
 
 ### Check GitHub Release
@@ -234,7 +234,7 @@ If you need to rollback a release:
 ### 1. Deprecate the bad version on npm
 
 ```bash
-npm deprecate browser-automation-mcp-server@<version> "This version has critical bugs, please upgrade to <fixed-version>"
+npm deprecate athena-browser-mcp@<version> "This version has critical bugs, please upgrade to <fixed-version>"
 ```
 
 ### 2. Release a new fixed version
@@ -289,7 +289,7 @@ Before releasing a major version, consider:
 2. **Test in real projects**:
 
    ```bash
-   npm install browser-automation-mcp-server@next
+   npm install athena-browser-mcp@next
    ```
 
 3. **Gather feedback** from users testing the pre-release

--- a/package.json
+++ b/package.json
@@ -1,11 +1,11 @@
 {
-  "name": "browser-automation-mcp-server",
+  "name": "athena-browser-mcp",
   "version": "1.0.0",
   "description": "MCP server for browser automation via Qt + CEF",
   "type": "module",
   "main": "dist/src/index.js",
   "bin": {
-    "browser-automation-mcp": "./dist/src/index.js"
+    "athena-browser-mcp": "./dist/src/index.js"
   },
   "scripts": {
     "build": "tsc",


### PR DESCRIPTION

- Update package name and bin command in package.json
- Update npm badge and documentation references in README.md
- Update all package references in RELEASING.md
- Update release workflow summary with new package name

This rename better aligns with the project repository name and provides a more concise package identifier.