### PR TITLE
docs: rewrite README with cleaner structure and tone

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ LLM-based agents operate under strict context window and token constraints.
 However, most browser automation tools expose entire DOMs or full accessibility trees to the model.
 
 This leads to:
+
 - Rapid token exhaustion
 - Higher inference costs
 - Reduced reliability as relevant signal is buried in noise
 
-In practice, agents spend more effort *finding* the right information than reasoning about it.
+In practice, agents spend more effort _finding_ the right information than reasoning about it.
 
 Athena exists to change the unit of information exposed to the model.
 
@@ -25,6 +26,7 @@ Athena exists to change the unit of information exposed to the model.
 Instead of exposing raw DOM structures or full accessibility trees, Athena produces **semantic page snapshots**.
 
 These snapshots are:
+
 - Compact and structured
 - Focused on user-visible intent
 - Designed for LLM recall and reasoning, not DOM completeness
@@ -44,6 +46,7 @@ At a high level:
 4. Actions are resolved against stable semantic identifiers rather than fragile selectors
 
 This separation keeps:
+
 - Browser lifecycle management isolated
 - Snapshots deterministic and low-entropy
 - Agent reasoning predictable and efficient
@@ -66,11 +69,13 @@ Results are task-dependent and should be treated as directional rather than abso
 ## What Athena Is (and Is Not)
 
 ### Athena is:
+
 - A semantic interface between browsers and LLM agents
 - An MCP server focused on reliability and efficiency
 - Designed for agent workflows, not test automation
 
 ### Athena is not:
+
 - A general-purpose browser
 - A visual testing or screenshot framework
 - A replacement for Playwright
@@ -90,6 +95,7 @@ Athena implements the **Model Context Protocol (MCP)** and works with:
 - Any MCP-compatible client
 
 Example workflows include:
+
 - Navigating complex web apps
 - Handling login and consent flows
 - Performing multi-step UI interactions with lower token usage
@@ -114,6 +120,7 @@ Configure the MCP server in your client according to its MCP integration instruc
 ## Architecture Overview
 
 Athena separates concerns into three layers:
+
 - **Browser lifecycle** — page creation, navigation, teardown
 - **Semantic snapshot generation** — regions, elements, identifiers
 - **Action resolution** — mapping agent intent to browser actions

--- a/README.md
+++ b/README.md
@@ -1,293 +1,135 @@
 # Athena Browser MCP
 
-[![CI](https://github.com/lespaceman/athena-browser-mcp/actions/workflows/ci.yml/badge.svg)](https://github.com/lespaceman/athena-browser-mcp/actions/workflows/ci.yml)
-[![npm version](https://badge.fury.io/js/athena-browser-mcp.svg)](https://www.npmjs.com/package/athena-browser-mcp)
-[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+An MCP server for browser automation that exposes semantic, token-efficient page representations optimized for LLM agents.
 
-MCP server for AI browser automation - 18 tools with semantic element targeting.
+---
 
-## Why Athena?
+## Motivation
 
-LLM agents face two hard constraints: limited context windows and expensive tokens. Yet browser automation requires understanding complex, ever-changing page state. Traditional tools dump raw accessibility trees or screenshots, wasting precious context and creating needle-in-haystack problems where agents struggle to locate relevant elements.
+LLM-based agents operate under strict context window and token constraints.
+However, most browser automation tools expose entire DOMs or full accessibility trees to the model.
 
-Athena solves this with **semantic page snapshots** - compact, structured representations designed for LLM consumption:
+This leads to:
+- Rapid token exhaustion
+- Higher inference costs
+- Reduced reliability as relevant signal is buried in noise
 
-- **Token-efficient** - Hierarchical layers and regions eliminate noise, fitting more page understanding into less context
-- **High recall** - Structured XML with semantic element IDs lets agents find elements without scanning entire DOM trees
-- **Intuitive querying** - `find_elements` with semantic filters (kind, label, region) so agents ask for what they need
-- **Stable references** - Semantic `eid`s survive DOM mutations, eliminating stale element errors
+In practice, agents spend more effort *finding* the right information than reasoning about it.
 
-The result: fewer tokens, faster task completion, and higher-quality outputs with fewer errors.
+Athena exists to change the unit of information exposed to the model.
 
-## Benchmark
+---
 
-Comparison between Athena Browser MCP and Playwright MCP on real-world browser automation tasks. Tests run in Claude Code with Claude Opus 4.5.
+## Core Idea: Semantic Page Snapshots
 
-| #   | Task                                                                                  | Agent          | Result     | Tokens Used | Time Taken |
-| --- | ------------------------------------------------------------------------------------- | -------------- | ---------- | ----------- | ---------- |
-| 1   | Login → Create wishlist "Summer Escapes" → Add beach property (Airbnb)                | **Athena**     | ✅ Success | 92,870      | 2m 08s     |
-|     |                                                                                       | **Playwright** | ✅ Success | 137,063     | 5m 23s     |
-| 2   | Bangkok Experiences → Food tour → Extract itinerary & pricing (Airbnb)                | **Athena**     | ✅ Success | 87,194      | 3m 27s     |
-|     |                                                                                       | **Playwright** | ✅ Success | 94,942      | 3m 38s     |
-| 3   | Miami → Beachfront stays under $300 → Top 3 names + prices (Airbnb)                   | **Athena**     | ✅ Success | 124,597     | 5m 38s     |
-|     |                                                                                       | **Playwright** | ✅ Success | 122,077     | 4m 51s     |
-| 4   | Paris → "Play" section → Top 5 titles + descriptions (Airbnb)                         | **Athena**     | ❌ Failed  | 146,575     | 4m 15s     |
-|     |                                                                                       | **Playwright** | ❌ Failed  | 189,495     | 7m 37s     |
-| 5   | Navigate Apple → find iPhone → configure iPhone 17 → add 256GB Black → confirm in bag | **Athena**     | ✅ Success | 65,629      | 3m 30s     |
-|     |                                                                                       | **Playwright** | ✅ Success | 102,754     | 6m 59s     |
+Instead of exposing raw DOM structures or full accessibility trees, Athena produces **semantic page snapshots**.
 
-**Total Results:**
+These snapshots are:
+- Compact and structured
+- Focused on user-visible intent
+- Designed for LLM recall and reasoning, not DOM completeness
+- Stable across layout shifts and DOM churn
 
-- **Tokens**: Athena used **125,341 fewer tokens** (~19.4% more efficient)
-- **Time**: Athena completed tasks **9m 30s faster** (~33.4% faster)
+The goal is not to mirror the browser, but to present the page in a form that aligns with how language models reason about interfaces.
 
-_Benchmark on a larger dataset coming soon._
+---
 
-## Architecture
+## How It Works
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                         AI Agent                                 │
-│  ┌────────────────────────────────────────────────────────────┐ │
-│  │ System Prompt: XML state (layers, actionables, atoms)      │ │
-│  └────────────────────────────────────────────────────────────┘ │
-└───────────────────────────┬─────────────────────────────────────┘
-                            │ MCP Protocol (stdio)
-┌───────────────────────────▼─────────────────────────────────────┐
-│  SESSION: launch_browser, connect_browser, close_page,          │
-│           close_session                                          │
-│  NAVIGATION: navigate, go_back, go_forward, reload               │
-│  OBSERVATION: capture_snapshot, find_elements, get_node_details  │
-│  INTERACTION: click, type, press, select, hover,                 │
-│               scroll_element_into_view, scroll_page              │
-└───────────────────────────┬─────────────────────────────────────┘
-                            │ Playwright + CDP
-┌───────────────────────────▼─────────────────────────────────────┐
-│                     Chromium Browser                             │
-└─────────────────────────────────────────────────────────────────┘
-```
+At a high level:
 
-## Tools
+1. The browser is controlled via Playwright and CDP
+2. The page is reduced into semantic regions and actionable elements
+3. A structured snapshot is generated and sent to the LLM
+4. Actions are resolved against stable semantic identifiers rather than fragile selectors
 
-### Session
+This separation keeps:
+- Browser lifecycle management isolated
+- Snapshots deterministic and low-entropy
+- Agent reasoning predictable and efficient
 
-| Tool              | Purpose                   | Input               |
-| ----------------- | ------------------------- | ------------------- |
-| `launch_browser`  | Launch new browser        | `{ headless? }`     |
-| `connect_browser` | Connect to existing (CDP) | `{ endpoint_url? }` |
-| `close_page`      | Close specific page       | `{ page_id }`       |
-| `close_session`   | Close entire browser      | `{}`                |
+---
 
-### Navigation
+## Benchmarks
 
-| Tool         | Purpose         | Input               |
-| ------------ | --------------- | ------------------- |
-| `navigate`   | Go to URL       | `{ url, page_id? }` |
-| `go_back`    | Browser back    | `{ page_id? }`      |
-| `go_forward` | Browser forward | `{ page_id? }`      |
-| `reload`     | Refresh page    | `{ page_id? }`      |
+Early benchmarks against Playwright MCP show:
 
-### Observation
+- **~19% fewer tokens consumed**
+- **~33% faster task completion**
+- Same or better success rates on common navigation tasks
 
-| Tool               | Purpose             | Input                                                             |
-| ------------------ | ------------------- | ----------------------------------------------------------------- |
-| `capture_snapshot` | Capture page state  | `{ page_id? }`                                                    |
-| `find_elements`    | Find by criteria    | `{ kind?, label?, region?, limit?, include_readable?, page_id? }` |
-| `get_node_details` | Get element details | `{ eid, page_id? }`                                               |
+Benchmarks were run using Claude Code on representative real-world tasks.
+Results are task-dependent and should be treated as directional rather than absolute.
 
-### Interaction
+---
 
-| Tool                       | Purpose            | Input                              |
-| -------------------------- | ------------------ | ---------------------------------- |
-| `click`                    | Click element      | `{ eid, page_id? }`                |
-| `type`                     | Type text          | `{ eid, text, clear?, page_id? }`  |
-| `press`                    | Press keyboard key | `{ key, modifiers?, page_id? }`    |
-| `select`                   | Select option      | `{ eid, value, page_id? }`         |
-| `hover`                    | Hover element      | `{ eid, page_id? }`                |
-| `scroll_element_into_view` | Scroll to element  | `{ eid, page_id? }`                |
-| `scroll_page`              | Scroll viewport    | `{ direction, amount?, page_id? }` |
+## What Athena Is (and Is Not)
 
-## Element IDs (eid)
+### Athena is:
+- A semantic interface between browsers and LLM agents
+- An MCP server focused on reliability and efficiency
+- Designed for agent workflows, not test automation
 
-Elements are identified by stable semantic IDs (`eid`) instead of transient DOM node IDs:
+### Athena is not:
+- A general-purpose browser
+- A visual testing or screenshot framework
+- A replacement for Playwright
 
-```xml
-<match eid="a1b2c3d4e5f6" kind="button" label="Sign In" region="header" />
-```
+Playwright remains the execution layer; Athena focuses on representation and reasoning.
 
-EIDs are computed from:
+---
 
-- Role/kind (button, link, input)
-- Accessible name (label text)
-- Landmark path (region + group hierarchy)
-- Position hint (screen zone, quadrant)
+## Usage
 
-This means the same logical element keeps its `eid` across page updates.
+Athena implements the **Model Context Protocol (MCP)** and works with:
 
-## Response Format
+- Claude Code
+- Claude Desktop
+- Cursor
+- VS Code
+- Any MCP-compatible client
 
-Tools return XML state responses with page understanding:
+Example workflows include:
+- Navigating complex web apps
+- Handling login and consent flows
+- Performing multi-step UI interactions with lower token usage
 
-```xml
-<state page_id="abc123" url="https://example.com" title="Example">
-  <layer type="main" active="true">
-    <actionables count="12">
-      <el eid="a1b2c3" kind="button" label="Sign In" />
-      <el eid="d4e5f6" kind="link" label="Forgot password?" />
-      <el eid="g7h8i9" kind="input" label="Email" type="email" />
-    </actionables>
-  </layer>
-  <atoms>
-    <viewport w="1280" h="720" />
-    <scroll x="0" y="0" />
-  </atoms>
-</state>
-```
+See the `examples/` directory for concrete agent workflows.
 
-### Layer Types
-
-| Layer     | Description                |
-| --------- | -------------------------- |
-| `main`    | Primary page content       |
-| `modal`   | Dialog overlays            |
-| `drawer`  | Slide-in panels            |
-| `popover` | Dropdowns, tooltips, menus |
-
-## Usage Examples
-
-### Login Flow
-
-```
-1. launch_browser { }
-   → XML state with initial page
-
-2. navigate { url: "https://example.com/login" }
-   → State shows login form elements
-
-3. find_elements { kind: "input", label: "email" }
-   → <match eid="abc123" kind="input" label="Email" />
-
-4. click { eid: "abc123" }
-   → Element focused
-
-5. type { eid: "abc123", text: "user@example.com" }
-   → Value filled
-
-6. press { key: "Tab" }
-   → Focus moved to password field
-
-7. type { eid: "def456", text: "password123" }
-   → Password filled
-
-8. press { key: "Enter" }
-   → Form submitted, navigation to dashboard
-```
-
-### Cookie Consent (Multi-Frame)
-
-```
-1. navigate { url: "https://news-site.com" }
-   → Modal layer detected (cookie consent iframe)
-
-2. find_elements { label: "Accept", kind: "button" }
-   → <match eid="xyz789" kind="button" label="Accept All" />
-
-3. click { eid: "xyz789" }
-   → Modal closed, main layer active
-```
+---
 
 ## Installation
 
 ```bash
+git clone https://github.com/lespaceman/athena-browser-mcp
+cd athena-browser-mcp
 npm install
 npm run build
 ```
 
-## Configuration
+Configure the MCP server in your client according to its MCP integration instructions.
 
-### Claude Desktop
+---
 
-Add to your Claude Desktop config:
+## Architecture Overview
 
-**macOS**: `~/Library/Application Support/Claude/claude_desktop_config.json`
-**Windows**: `%APPDATA%\Claude\claude_desktop_config.json`
-**Linux**: `~/.config/Claude/claude_desktop_config.json`
+Athena separates concerns into three layers:
+- **Browser lifecycle** — page creation, navigation, teardown
+- **Semantic snapshot generation** — regions, elements, identifiers
+- **Action resolution** — mapping agent intent to browser actions
 
-```json
-{
-  "mcpServers": {
-    "browser": {
-      "command": "npx",
-      "args": ["athena-browser-mcp@latest"]
-    }
-  }
-}
-```
+This separation allows each layer to evolve independently while keeping agent-visible behavior stable.
 
-### Claude Code
+---
 
-```bash
-claude mcp add athena-browser-mcp npx athena-browser-mcp@latest
-```
+## Status
 
-### VS Code
+Athena is under active development.
+APIs and snapshot formats may evolve as real-world agent usage informs the design.
 
-```bash
-code --add-mcp '{"name":"athena-browser-mcp","command":"npx","args":["athena-browser-mcp@latest"]}'
-```
+Feedback from practitioners building agent systems is especially welcome.
 
-### Cursor
-
-Go to **Cursor Settings → MCP → Add new MCP Server**. Use command type with:
-
-```
-npx athena-browser-mcp@latest
-```
-
-### Codex
-
-```bash
-codex mcp add athena-browser-mcp npx athena-browser-mcp@latest
-```
-
-### Gemini CLI
-
-```bash
-gemini mcp add -s user athena-browser-mcp -- npx athena-browser-mcp@latest
-```
-
-### Connect to Existing Browser
-
-To connect to an existing Chromium browser with CDP enabled:
-
-```bash
-# Start Chrome with remote debugging
-google-chrome --remote-debugging-port=9222
-
-# Or use environment variables
-export CEF_BRIDGE_HOST=127.0.0.1
-export CEF_BRIDGE_PORT=9222
-```
-
-Then use `connect_browser` instead of `launch_browser`.
-
-### Environment Variables
-
-| Variable          | Description          | Default     |
-| ----------------- | -------------------- | ----------- |
-| `CEF_BRIDGE_HOST` | CDP host for connect | `127.0.0.1` |
-| `CEF_BRIDGE_PORT` | CDP port for connect | `9223`      |
-
-## Development
-
-```bash
-npm run build          # Compile TypeScript
-npm run type-check     # TypeScript type checking
-npm run lint           # ESLint
-npm run format         # Prettier format
-npm run check          # Run all checks
-npm test               # Run tests
-```
+---
 
 ## License
 


### PR DESCRIPTION
Simplify README to focus on motivation, core ideas, and what Athena is and isn't. Removes detailed tool documentation in favor of a more approachable technical document that explains why before how.