### PR TITLE
feat: use descriptive attribute names in XML snapshots

### DIFF
--- a/src/state/state-renderer.ts
+++ b/src/state/state-renderer.ts
@@ -117,13 +117,13 @@ function renderActionable(item: ActionableInfo, _diff?: StateResponseObject['dif
   const tag = mapKindToTag(item.kind);
   const attrs: string[] = [`id="${item.eid}"`];
 
-  // State flags (descriptive names for clarity)
-  if (!item.ena) attrs.push(`enabled="0"`);
-  if (!item.vis) attrs.push(`visible="0"`);
-  if (item.chk) attrs.push(`checked="1"`);
-  if (item.sel) attrs.push(`selected="1"`);
-  if (item.exp) attrs.push(`expanded="1"`);
-  if (item.foc) attrs.push(`focused="1"`);
+  // State flags (descriptive names with boolean values)
+  if (!item.ena) attrs.push(`enabled="false"`);
+  if (!item.vis) attrs.push(`visible="false"`);
+  if (item.chk) attrs.push(`checked="true"`);
+  if (item.sel) attrs.push(`selected="true"`);
+  if (item.exp) attrs.push(`expanded="true"`);
+  if (item.foc) attrs.push(`focused="true"`);
 
   // Attributes
   if (item.val_hint) attrs.push(`val="${escapeXml(item.val_hint)}"`);

--- a/src/state/state-renderer.ts
+++ b/src/state/state-renderer.ts
@@ -117,13 +117,13 @@ function renderActionable(item: ActionableInfo, _diff?: StateResponseObject['dif
   const tag = mapKindToTag(item.kind);
   const attrs: string[] = [`id="${item.eid}"`];
 
-  // State flags (compact)
-  if (!item.ena) attrs.push(`e="0"`);
-  if (!item.vis) attrs.push(`v="0"`);
-  if (item.chk) attrs.push(`chk="1"`);
-  if (item.sel) attrs.push(`sel="1"`);
-  if (item.exp) attrs.push(`exp="1"`);
-  if (item.foc) attrs.push(`foc="1"`);
+  // State flags (descriptive names for clarity)
+  if (!item.ena) attrs.push(`enabled="0"`);
+  if (!item.vis) attrs.push(`visible="0"`);
+  if (item.chk) attrs.push(`checked="1"`);
+  if (item.sel) attrs.push(`selected="1"`);
+  if (item.exp) attrs.push(`expanded="1"`);
+  if (item.foc) attrs.push(`focused="1"`);
 
   // Attributes
   if (item.val_hint) attrs.push(`val="${escapeXml(item.val_hint)}"`);

--- a/src/tools/response-builder.ts
+++ b/src/tools/response-builder.ts
@@ -151,12 +151,14 @@ export function buildFindElementsResponse(
 
     // Add state flags
     if (m.state) {
-      if (m.state.visible !== undefined) attrs.push(`visible="${m.state.visible ? '1' : '0'}"`);
-      if (m.state.enabled !== undefined) attrs.push(`enabled="${m.state.enabled ? '1' : '0'}"`);
-      if (m.state.checked) attrs.push(`checked="1"`);
-      if (m.state.expanded) attrs.push(`expanded="1"`);
-      if (m.state.selected) attrs.push(`selected="1"`);
-      if (m.state.focused) attrs.push(`focused="1"`);
+      if (m.state.visible !== undefined)
+        attrs.push(`visible="${m.state.visible ? 'true' : 'false'}"`);
+      if (m.state.enabled !== undefined)
+        attrs.push(`enabled="${m.state.enabled ? 'true' : 'false'}"`);
+      if (m.state.checked) attrs.push(`checked="true"`);
+      if (m.state.expanded) attrs.push(`expanded="true"`);
+      if (m.state.selected) attrs.push(`selected="true"`);
+      if (m.state.focused) attrs.push(`focused="true"`);
     }
 
     // Add common attributes
@@ -227,16 +229,16 @@ export function buildGetNodeDetailsResponse(
   if (node.state) {
     const stateAttrs: string[] = [];
     if (node.state.visible !== undefined)
-      stateAttrs.push(`visible="${node.state.visible ? '1' : '0'}"`);
+      stateAttrs.push(`visible="${node.state.visible ? 'true' : 'false'}"`);
     if (node.state.enabled !== undefined)
-      stateAttrs.push(`enabled="${node.state.enabled ? '1' : '0'}"`);
-    if (node.state.checked) stateAttrs.push(`checked="1"`);
-    if (node.state.expanded) stateAttrs.push(`expanded="1"`);
-    if (node.state.selected) stateAttrs.push(`selected="1"`);
-    if (node.state.focused) stateAttrs.push(`focused="1"`);
-    if (node.state.required) stateAttrs.push(`required="1"`);
-    if (node.state.invalid) stateAttrs.push(`invalid="1"`);
-    if (node.state.readonly) stateAttrs.push(`readonly="1"`);
+      stateAttrs.push(`enabled="${node.state.enabled ? 'true' : 'false'}"`);
+    if (node.state.checked) stateAttrs.push(`checked="true"`);
+    if (node.state.expanded) stateAttrs.push(`expanded="true"`);
+    if (node.state.selected) stateAttrs.push(`selected="true"`);
+    if (node.state.focused) stateAttrs.push(`focused="true"`);
+    if (node.state.required) stateAttrs.push(`required="true"`);
+    if (node.state.invalid) stateAttrs.push(`invalid="true"`);
+    if (node.state.readonly) stateAttrs.push(`readonly="true"`);
     if (stateAttrs.length > 0) {
       lines.push(`    <state ${stateAttrs.join(' ')} />`);
     }

--- a/src/tools/response-builder.ts
+++ b/src/tools/response-builder.ts
@@ -151,12 +151,12 @@ export function buildFindElementsResponse(
 
     // Add state flags
     if (m.state) {
-      if (m.state.visible !== undefined) attrs.push(`vis="${m.state.visible ? '1' : '0'}"`);
-      if (m.state.enabled !== undefined) attrs.push(`ena="${m.state.enabled ? '1' : '0'}"`);
-      if (m.state.checked) attrs.push(`chk="1"`);
-      if (m.state.expanded) attrs.push(`exp="1"`);
-      if (m.state.selected) attrs.push(`sel="1"`);
-      if (m.state.focused) attrs.push(`foc="1"`);
+      if (m.state.visible !== undefined) attrs.push(`visible="${m.state.visible ? '1' : '0'}"`);
+      if (m.state.enabled !== undefined) attrs.push(`enabled="${m.state.enabled ? '1' : '0'}"`);
+      if (m.state.checked) attrs.push(`checked="1"`);
+      if (m.state.expanded) attrs.push(`expanded="1"`);
+      if (m.state.selected) attrs.push(`selected="1"`);
+      if (m.state.focused) attrs.push(`focused="1"`);
     }
 
     // Add common attributes
@@ -227,16 +227,16 @@ export function buildGetNodeDetailsResponse(
   if (node.state) {
     const stateAttrs: string[] = [];
     if (node.state.visible !== undefined)
-      stateAttrs.push(`vis="${node.state.visible ? '1' : '0'}"`);
+      stateAttrs.push(`visible="${node.state.visible ? '1' : '0'}"`);
     if (node.state.enabled !== undefined)
-      stateAttrs.push(`ena="${node.state.enabled ? '1' : '0'}"`);
-    if (node.state.checked) stateAttrs.push(`chk="1"`);
-    if (node.state.expanded) stateAttrs.push(`exp="1"`);
-    if (node.state.selected) stateAttrs.push(`sel="1"`);
-    if (node.state.focused) stateAttrs.push(`foc="1"`);
-    if (node.state.required) stateAttrs.push(`req="1"`);
-    if (node.state.invalid) stateAttrs.push(`inv="1"`);
-    if (node.state.readonly) stateAttrs.push(`rdo="1"`);
+      stateAttrs.push(`enabled="${node.state.enabled ? '1' : '0'}"`);
+    if (node.state.checked) stateAttrs.push(`checked="1"`);
+    if (node.state.expanded) stateAttrs.push(`expanded="1"`);
+    if (node.state.selected) stateAttrs.push(`selected="1"`);
+    if (node.state.focused) stateAttrs.push(`focused="1"`);
+    if (node.state.required) stateAttrs.push(`required="1"`);
+    if (node.state.invalid) stateAttrs.push(`invalid="1"`);
+    if (node.state.readonly) stateAttrs.push(`readonly="1"`);
     if (stateAttrs.length > 0) {
       lines.push(`    <state ${stateAttrs.join(' ')} />`);
     }

--- a/tests/unit/state/element-registry-eid-consistency.test.ts
+++ b/tests/unit/state/element-registry-eid-consistency.test.ts
@@ -80,8 +80,8 @@ function extractEidsWithFocusFlag(xml: string): { eid: string; focused: boolean;
     const idMatch = idRegex.exec(attrs);
     if (!idMatch) continue;
 
-    // Check for foc="1"
-    const hasFocus = attrs.includes('foc="1"');
+    // Check for focused="1"
+    const hasFocus = attrs.includes('focused="1"');
 
     results.push({
       eid: idMatch[1],

--- a/tests/unit/state/element-registry-eid-consistency.test.ts
+++ b/tests/unit/state/element-registry-eid-consistency.test.ts
@@ -80,8 +80,8 @@ function extractEidsWithFocusFlag(xml: string): { eid: string; focused: boolean;
     const idMatch = idRegex.exec(attrs);
     if (!idMatch) continue;
 
-    // Check for focused="1"
-    const hasFocus = attrs.includes('focused="1"');
+    // Check for focused="true"
+    const hasFocus = attrs.includes('focused="true"');
 
     results.push({
       eid: idMatch[1],


### PR DESCRIPTION
## Summary

- Replace abbreviated state attributes with full descriptive names for better LLM readability
- Use boolean text values (`"true"`/`"false"`) instead of numeric (`"0"`/`"1"`)
- Users reported confusion with cryptic attributes like `e="0"` not clearly indicating disabled elements
- Minimal token impact (~50-100 extra tokens per page)

**Before:**
```xml
<rad id="553a5232d744" e="0" val="fullprice">Buy...</rad>
<rad id="6fa4466f3e24" chk="1" foc="1" val="512gb">512GB...</rad>
```

**After:**
```xml
<rad id="553a5232d744" enabled="false" val="fullprice">Buy...</rad>
<rad id="6fa4466f3e24" checked="true" focused="true" val="512gb">512GB...</rad>
```

## Test plan

- [x] All existing tests pass (1277 tests)
- [x] Type check passes
- [x] Lint passes
- [ ] Manual test with MCP inspector: `npm run mcp:inspect`

🤖 Generated with [Claude Code](https://claude.ai/code)