### PR TITLE
fix: stabilize element IDs across scrolling

### DIFF
--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -409,20 +409,6 @@ export interface ScoringContext {
 // ============================================================================
 
 /**
- * Element identity for tracking across snapshots.
- */
-export interface ElementIdentity {
-  eid: string;
-  role: string;
-  name: string;
-  href?: string;
-  landmarkPath: string[];
-  nthOfType: number;
-  layer: string;
-  lastSeenStep: number;
-}
-
-/**
  * EID to node mapping.
  */
 export type EidMap = Map<string, ReadableNode>;


### PR DESCRIPTION
## Summary

- Fix EID instability when scrolling by removing viewport-dependent data from `computePositionHint()`
- Remove `screen_zone` and `bbox` quadrant from EID computation (these change with scroll position)
- Keep only `group_path` for semantic context (scroll-stable)
- Clean up dead code: `computeNthOfType()`, `buildElementIdentity()`, `ElementIdentity` type

## Problem

Element IDs (EIDs) were changing when scrolling because `computePositionHint()` included viewport-relative data:
- `screen_zone` changes with scroll position (above-fold → below-fold)
- `computeQuadrant()` uses fixed thresholds on viewport coordinates

**Result**: Same element got different EIDs after scrolling, breaking element tracking.

## Solution

Remove viewport-dependent components while keeping semantic context (`group_path`). The collision resolution mechanism (`resolveEidCollision`) handles any increased collision rate by appending `-2`, `-3` suffixes.

## Test plan

- [x] Added failing test for scroll stability before fix
- [x] All 1265 tests pass
- [x] TypeScript type-check passes
- [x] ESLint passes

🤖 Generated with [Claude Code](https://claude.ai/code)