### PR TITLE
feat: reduce verbosity in action responses

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "eslint": "^9.39.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-prettier": "^5.5.4",
+        "jsdom": "^27.4.0",
         "prettier": "^3.7.0",
         "typescript": "^5.0.0",
         "typescript-eslint": "^8.53.0",
@@ -34,6 +35,48 @@
       "engines": {
         "node": ">=20.0.0"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.1.tgz",
+      "integrity": "sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "lru-cache": "^11.2.4"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.7.6",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.6.tgz",
+      "integrity": "sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.4"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/helper-string-parser": {
       "version": "7.27.1",
@@ -90,6 +133,141 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
       "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.25",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.25.tgz",
+      "integrity": "sha512-g0Kw9W3vjx5BEBAF8c5Fm2NcB/Fs8jJXh85aXqwEXiL+tqtOut07TWgyaGzAAfTM+gKckrrncyeGEZPcaRgm2Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -703,6 +881,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.8.0.tgz",
+      "integrity": "sha512-8JPn18Bcp8Uo1T82gR8lh2guEOa5KKU/IEKvvdp0sgmi7coPBWf1Doi1EXsGZb2ehc8ym/StJCjffYV+ne7sXQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@exodus/crypto": "^1.0.0-rc.4"
+      },
+      "peerDependenciesMeta": {
+        "@exodus/crypto": {
+          "optional": true
+        }
       }
     },
     "node_modules/@hono/node-server": {
@@ -1713,6 +1909,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.17.1",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
@@ -1797,6 +2003,16 @@
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
+      }
     },
     "node_modules/body-parser": {
       "version": "2.2.2",
@@ -2020,6 +2236,50 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.0.tgz",
+      "integrity": "sha512-BnBS08aLUM+DKamupXs3w2tJJoqU+AkaE/+6vQxi/G/DPmIZFJJp9Dkb1kM03AZx8ADehDUZgsNxju3mPXZYIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -2036,6 +2296,13 @@
           "optional": true
         }
       }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/deep-is": {
       "version": "0.1.4",
@@ -2087,6 +2354,19 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -2791,6 +3071,19 @@
         "node": ">=16.9.0"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
@@ -2821,6 +3114,34 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
       }
     },
     "node_modules/iconv-lite": {
@@ -2914,6 +3235,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/is-promise": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -2994,6 +3322,68 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdom": {
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsdom/node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/json-buffer": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
@@ -3067,6 +3457,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/lru-cache": {
+      "version": "11.2.4",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.4.tgz",
+      "integrity": "sha512-B5Y16Jr9LB9dHVkh6ZevG+vAbOsNOYCX+sXvFWFu7B3Iz5mijW3zdbMyhsh8ANd2mSWBYdJgnqi+mL7/LrOPYg==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -3113,6 +3513,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -3324,6 +3731,19 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
       }
     },
     "node_modules/parseurl": {
@@ -3683,6 +4103,19 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/semver": {
       "version": "7.7.3",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -3898,6 +4331,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/synckit": {
       "version": "0.11.11",
       "resolved": "https://registry.npmjs.org/synckit/-/synckit-0.11.11.tgz",
@@ -3989,6 +4429,26 @@
         "node": ">=14.0.0"
       }
     },
+    "node_modules/tldts": {
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
+      "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.19"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
+      "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -3996,6 +4456,32 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4308,6 +4794,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4376,6 +4909,23 @@
           "optional": true
         }
       }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "eslint": "^9.39.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-prettier": "^5.5.4",
+    "jsdom": "^27.4.0",
     "prettier": "^3.7.0",
     "typescript": "^5.0.0",
     "typescript-eslint": "^8.53.0",

--- a/src/observation/observation.types.ts
+++ b/src/observation/observation.types.ts
@@ -65,6 +65,22 @@ export const SIGNIFICANCE_WEIGHTS: Record<keyof SignificanceSignals, number> = {
 export const SIGNIFICANCE_THRESHOLD = 4;
 
 /**
+ * Higher threshold for attaching observations to tool responses.
+ *
+ * Two-Tier Filtering Strategy:
+ * ----------------------------
+ * Tier 1 (Browser-side, threshold=4): SIGNIFICANCE_THRESHOLD
+ *   - Applied in observer-script.ts during DOM mutation capture
+ *   - Filters out clearly insignificant mutations at capture time
+ *
+ * Tier 2 (Attachment-time, threshold=5): ATTACHMENT_SIGNIFICANCE_THRESHOLD
+ *   - Applied when attaching observations to snapshot responses
+ *   - Requires semantic signal (ARIA role) + visual/structural signals
+ *   - Reduces response verbosity for the LLM
+ */
+export const ATTACHMENT_SIGNIFICANCE_THRESHOLD = 5;
+
+/**
  * Compute significance score from signals.
  */
 export function computeSignificance(signals: SignificanceSignals): number {

--- a/src/observation/observation.types.ts
+++ b/src/observation/observation.types.ts
@@ -62,7 +62,7 @@ export const SIGNIFICANCE_WEIGHTS: Record<keyof SignificanceSignals, number> = {
   wasShortLived: 2,
 };
 
-export const SIGNIFICANCE_THRESHOLD = 3;
+export const SIGNIFICANCE_THRESHOLD = 4;
 
 /**
  * Compute significance score from signals.

--- a/src/observation/observer-script.ts
+++ b/src/observation/observer-script.ts
@@ -87,10 +87,12 @@ export const OBSERVATION_OBSERVER_SCRIPT = `
 
   /**
    * Get clean text content from an element, excluding CSS/JS content.
-   * Uses TreeWalker to iterate only text nodes, skipping those inside excluded tags.
-   * @param el - The element to extract text from
-   * @param maxLength - Maximum length of text to extract
-   * @returns Clean text content without style/script content
+   * Uses TreeWalker to iterate only text nodes, skipping those inside
+   * excluded tags (STYLE, SCRIPT, NOSCRIPT, TEMPLATE, SVG).
+   *
+   * @param {Element} el - The DOM element to extract text from
+   * @param {number} maxLength - Maximum text length (truncates result)
+   * @returns {string} Clean text content, space-joined, truncated to maxLength
    */
   function getCleanTextContent(el, maxLength) {
     // If element itself is an excluded tag, return empty
@@ -106,9 +108,6 @@ export const OBSERVATION_OBSERVER_SCRIPT = `
             return 2; // FILTER_REJECT
           }
           parent = parent.parentElement;
-        }
-        if (node.parentElement && EXCLUDED_TEXT_TAGS.has(node.parentElement.tagName.toUpperCase())) {
-          return 2; // FILTER_REJECT
         }
         return 1; // FILTER_ACCEPT
       }

--- a/src/state/diff-engine.ts
+++ b/src/state/diff-engine.ts
@@ -438,7 +438,7 @@ function computeAtomicDiffs(prev: BaseSnapshot, curr: BaseSnapshot): AtomChange[
  *
  * TODO: Remove or make permanent after evaluation is complete.
  */
-const TRACK_ALL_READABLE_MUTATIONS = true;
+const TRACK_ALL_READABLE_MUTATIONS = false;
 
 /**
  * Maximum character length for mutation text content.

--- a/src/tools/browser-tools.ts
+++ b/src/tools/browser-tools.ts
@@ -16,6 +16,7 @@ import {
   scrollPage as scrollPageByAmount,
 } from '../snapshot/index.js';
 import { observationAccumulator } from '../observation/index.js';
+import { ATTACHMENT_SIGNIFICANCE_THRESHOLD } from '../observation/observation.types.js';
 import type { NodeDetails } from './tool-schemas.js';
 import {
   LaunchBrowserInputSchema,
@@ -569,7 +570,10 @@ export async function captureSnapshot(
   const snapshot = captureResult.snapshot;
 
   // Filter observations to reduce noise (threshold 5 requires semantic signals)
-  const filteredObservations = observationAccumulator.filterBySignificance(observations, 5);
+  const filteredObservations = observationAccumulator.filterBySignificance(
+    observations,
+    ATTACHMENT_SIGNIFICANCE_THRESHOLD
+  );
 
   // Attach accumulated observations to snapshot if any
   if (filteredObservations.sincePrevious.length > 0) {

--- a/src/tools/browser-tools.ts
+++ b/src/tools/browser-tools.ts
@@ -568,9 +568,12 @@ export async function captureSnapshot(
   handle = captureResult.handle;
   const snapshot = captureResult.snapshot;
 
+  // Filter observations to reduce noise (threshold 5 requires semantic signals)
+  const filteredObservations = observationAccumulator.filterBySignificance(observations, 5);
+
   // Attach accumulated observations to snapshot if any
-  if (observations.sincePrevious.length > 0) {
-    snapshot.observations = observations;
+  if (filteredObservations.sincePrevious.length > 0) {
+    snapshot.observations = filteredObservations;
   }
 
   snapshotStore.store(page_id, snapshot);

--- a/src/tools/execute-action.ts
+++ b/src/tools/execute-action.ts
@@ -274,7 +274,10 @@ export async function executeAction(
   );
 
   // Attach observations to snapshot if any were captured
-  if (filteredObservations.duringAction.length > 0 || filteredObservations.sincePrevious.length > 0) {
+  if (
+    filteredObservations.duringAction.length > 0 ||
+    filteredObservations.sincePrevious.length > 0
+  ) {
     snapshot.observations = filteredObservations;
   }
 
@@ -387,7 +390,10 @@ export async function executeActionWithRetry(
   );
 
   // Attach observations to snapshot if any were captured
-  if (filteredObservations.duringAction.length > 0 || filteredObservations.sincePrevious.length > 0) {
+  if (
+    filteredObservations.duringAction.length > 0 ||
+    filteredObservations.sincePrevious.length > 0
+  ) {
     snapshot.observations = filteredObservations;
   }
 
@@ -641,7 +647,10 @@ export async function executeActionWithOutcome(
   );
 
   // Attach observations to snapshot if any were captured
-  if (filteredObservations.duringAction.length > 0 || filteredObservations.sincePrevious.length > 0) {
+  if (
+    filteredObservations.duringAction.length > 0 ||
+    filteredObservations.sincePrevious.length > 0
+  ) {
     snapshot.observations = filteredObservations;
   }
 

--- a/src/tools/execute-action.ts
+++ b/src/tools/execute-action.ts
@@ -266,9 +266,12 @@ export async function executeAction(
   const captureResult = await capture();
   const snapshot = captureResult.snapshot;
 
+  // Filter observations to reduce noise (threshold 5 requires semantic signals)
+  const filteredObservations = observationAccumulator.filterBySignificance(observations, 5);
+
   // Attach observations to snapshot if any were captured
-  if (observations.duringAction.length > 0 || observations.sincePrevious.length > 0) {
-    snapshot.observations = observations;
+  if (filteredObservations.duringAction.length > 0 || filteredObservations.sincePrevious.length > 0) {
+    snapshot.observations = filteredObservations;
   }
 
   // Generate state response using StateManager
@@ -373,9 +376,12 @@ export async function executeActionWithRetry(
   const captureResult = await capture();
   const snapshot = captureResult.snapshot;
 
+  // Filter observations to reduce noise (threshold 5 requires semantic signals)
+  const filteredObservations = observationAccumulator.filterBySignificance(observations, 5);
+
   // Attach observations to snapshot if any were captured
-  if (observations.duringAction.length > 0 || observations.sincePrevious.length > 0) {
-    snapshot.observations = observations;
+  if (filteredObservations.duringAction.length > 0 || filteredObservations.sincePrevious.length > 0) {
+    snapshot.observations = filteredObservations;
   }
 
   // Generate state response using StateManager
@@ -621,9 +627,12 @@ export async function executeActionWithOutcome(
   const captureResult = await capture();
   const snapshot = captureResult.snapshot;
 
+  // Filter observations to reduce noise (threshold 5 requires semantic signals)
+  const filteredObservations = observationAccumulator.filterBySignificance(observations, 5);
+
   // Attach observations to snapshot if any were captured
-  if (observations.duringAction.length > 0 || observations.sincePrevious.length > 0) {
-    snapshot.observations = observations;
+  if (filteredObservations.duringAction.length > 0 || filteredObservations.sincePrevious.length > 0) {
+    snapshot.observations = filteredObservations;
   }
 
   // Generate state response using StateManager

--- a/src/tools/execute-action.ts
+++ b/src/tools/execute-action.ts
@@ -19,6 +19,7 @@ import type { ClickOutcome } from '../state/element-ref.types.js';
 import type { RuntimeHealth } from '../state/health.types.js';
 import { createHealthyRuntime } from '../state/health.types.js';
 import { observationAccumulator } from '../observation/index.js';
+import { ATTACHMENT_SIGNIFICANCE_THRESHOLD } from '../observation/observation.types.js';
 import {
   waitForNetworkQuiet,
   ACTION_NETWORK_IDLE_TIMEOUT_MS,
@@ -267,7 +268,10 @@ export async function executeAction(
   const snapshot = captureResult.snapshot;
 
   // Filter observations to reduce noise (threshold 5 requires semantic signals)
-  const filteredObservations = observationAccumulator.filterBySignificance(observations, 5);
+  const filteredObservations = observationAccumulator.filterBySignificance(
+    observations,
+    ATTACHMENT_SIGNIFICANCE_THRESHOLD
+  );
 
   // Attach observations to snapshot if any were captured
   if (filteredObservations.duringAction.length > 0 || filteredObservations.sincePrevious.length > 0) {
@@ -377,7 +381,10 @@ export async function executeActionWithRetry(
   const snapshot = captureResult.snapshot;
 
   // Filter observations to reduce noise (threshold 5 requires semantic signals)
-  const filteredObservations = observationAccumulator.filterBySignificance(observations, 5);
+  const filteredObservations = observationAccumulator.filterBySignificance(
+    observations,
+    ATTACHMENT_SIGNIFICANCE_THRESHOLD
+  );
 
   // Attach observations to snapshot if any were captured
   if (filteredObservations.duringAction.length > 0 || filteredObservations.sincePrevious.length > 0) {
@@ -628,7 +635,10 @@ export async function executeActionWithOutcome(
   const snapshot = captureResult.snapshot;
 
   // Filter observations to reduce noise (threshold 5 requires semantic signals)
-  const filteredObservations = observationAccumulator.filterBySignificance(observations, 5);
+  const filteredObservations = observationAccumulator.filterBySignificance(
+    observations,
+    ATTACHMENT_SIGNIFICANCE_THRESHOLD
+  );
 
   // Attach observations to snapshot if any were captured
   if (filteredObservations.duringAction.length > 0 || filteredObservations.sincePrevious.length > 0) {

--- a/tests/unit/observation/observation-accumulator.test.ts
+++ b/tests/unit/observation/observation-accumulator.test.ts
@@ -276,12 +276,12 @@ describe('ObservationAccumulator', () => {
       expect(filtered.duringAction[0].significance).toBe(5);
     });
 
-    it('should use default threshold of 3', () => {
+    it('should use default threshold of 4', () => {
       const observations = {
         duringAction: [
           {
             type: 'appeared' as const,
-            significance: 2,
+            significance: 3,
             signals: {} as never,
             content: { tag: 'div', text: '', hasInteractives: false },
             timestamp: 0,
@@ -289,7 +289,7 @@ describe('ObservationAccumulator', () => {
           },
           {
             type: 'appeared' as const,
-            significance: 3,
+            significance: 4,
             signals: {} as never,
             content: { tag: 'div', text: '', hasInteractives: false },
             timestamp: 0,
@@ -302,7 +302,7 @@ describe('ObservationAccumulator', () => {
       const filtered = accumulator.filterBySignificance(observations);
 
       expect(filtered.duringAction).toHaveLength(1);
-      expect(filtered.duringAction[0].significance).toBe(3);
+      expect(filtered.duringAction[0].significance).toBe(4);
     });
   });
 

--- a/tests/unit/observation/observation.types.test.ts
+++ b/tests/unit/observation/observation.types.test.ts
@@ -146,25 +146,37 @@ describe('Significance Scoring', () => {
   });
 
   describe('SIGNIFICANCE_THRESHOLD', () => {
-    it('should be 3', () => {
-      expect(SIGNIFICANCE_THRESHOLD).toBe(3);
+    it('should be 4', () => {
+      expect(SIGNIFICANCE_THRESHOLD).toBe(4);
     });
 
-    it('should mean single semantic signal meets threshold', () => {
+    it('should mean single semantic signal does not meet threshold', () => {
       const signals = createSignals({ hasAlertRole: true });
-      expect(computeSignificance(signals)).toBeGreaterThanOrEqual(SIGNIFICANCE_THRESHOLD);
+      // 3 < 4
+      expect(computeSignificance(signals)).toBeLessThan(SIGNIFICANCE_THRESHOLD);
     });
 
     it('should mean single visual signal does not meet threshold', () => {
       const signals = createSignals({ isFixedOrSticky: true });
+      // 2 < 4
       expect(computeSignificance(signals)).toBeLessThan(SIGNIFICANCE_THRESHOLD);
     });
 
-    it('should mean two visual signals meet threshold', () => {
+    it('should mean two visual signals do not meet threshold', () => {
       const signals = createSignals({
         isFixedOrSticky: true, // 2
         hasHighZIndex: true, // 1
       });
+      // 2 + 1 = 3 < 4
+      expect(computeSignificance(signals)).toBeLessThan(SIGNIFICANCE_THRESHOLD);
+    });
+
+    it('should mean semantic signal plus visual meets threshold', () => {
+      const signals = createSignals({
+        hasAlertRole: true, // 3
+        isVisibleInViewport: true, // 2
+      });
+      // 3 + 2 = 5 >= 4
       expect(computeSignificance(signals)).toBeGreaterThanOrEqual(SIGNIFICANCE_THRESHOLD);
     });
   });

--- a/tests/unit/observation/observer-script.test.ts
+++ b/tests/unit/observation/observer-script.test.ts
@@ -64,7 +64,9 @@ describe('OBSERVATION_OBSERVER_SCRIPT', () => {
 
       eval(extractedFunction);
 
-      getCleanTextContent = (window as unknown as { __testGetCleanTextContent: typeof getCleanTextContent }).__testGetCleanTextContent;
+      getCleanTextContent = (
+        window as unknown as { __testGetCleanTextContent: typeof getCleanTextContent }
+      ).__testGetCleanTextContent;
     });
 
     it('should extract text content from simple elements', () => {

--- a/tests/unit/observation/observer-script.test.ts
+++ b/tests/unit/observation/observer-script.test.ts
@@ -17,6 +17,9 @@ describe('OBSERVATION_OBSERVER_SCRIPT', () => {
     beforeEach(() => {
       // Execute the script to make getCleanTextContent available
       // We extract just the getCleanTextContent function for isolated testing
+      //
+      // WARNING: This implementation must be kept in sync with observer-script.ts
+      // See "sync validation" tests below that verify key aspects match the source.
       const extractedFunction = `
         const EXCLUDED_TEXT_TAGS = new Set(['STYLE', 'SCRIPT', 'NOSCRIPT', 'TEMPLATE', 'SVG']);
 
@@ -33,9 +36,6 @@ describe('OBSERVATION_OBSERVER_SCRIPT', () => {
                   return 2; // FILTER_REJECT
                 }
                 parent = parent.parentElement;
-              }
-              if (node.parentElement && EXCLUDED_TEXT_TAGS.has(node.parentElement.tagName.toUpperCase())) {
-                return 2;
               }
               return 1; // FILTER_ACCEPT
             }
@@ -271,6 +271,19 @@ describe('OBSERVATION_OBSERVER_SCRIPT', () => {
     it('should use getCleanTextContent in captureEntry', () => {
       // Verify the script uses getCleanTextContent in captureEntry function
       expect(OBSERVATION_OBSERVER_SCRIPT).toContain('getCleanTextContent(el, MAX_TEXT_LENGTH)');
+    });
+  });
+
+  describe('sync validation', () => {
+    it('should have matching EXCLUDED_TEXT_TAGS in source', () => {
+      const expectedTags = ['STYLE', 'SCRIPT', 'NOSCRIPT', 'TEMPLATE', 'SVG'];
+      for (const tag of expectedTags) {
+        expect(OBSERVATION_OBSERVER_SCRIPT).toContain(`'${tag}'`);
+      }
+    });
+
+    it('should have getCleanTextContent with same signature', () => {
+      expect(OBSERVATION_OBSERVER_SCRIPT).toContain('function getCleanTextContent(el, maxLength)');
     });
   });
 });

--- a/tests/unit/observation/observer-script.test.ts
+++ b/tests/unit/observation/observer-script.test.ts
@@ -1,0 +1,276 @@
+/**
+ * Observer Script Tests
+ *
+ * Tests for the browser-side DOM observation script, specifically the text extraction
+ * logic that should exclude CSS and JavaScript content.
+ *
+ * @vitest-environment jsdom
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import { OBSERVATION_OBSERVER_SCRIPT } from '../../../src/observation/observer-script.js';
+
+describe('OBSERVATION_OBSERVER_SCRIPT', () => {
+  describe('getCleanTextContent', () => {
+    let getCleanTextContent: (el: Element, maxLength: number) => string;
+
+    beforeEach(() => {
+      // Execute the script to make getCleanTextContent available
+      // We extract just the getCleanTextContent function for isolated testing
+      const extractedFunction = `
+        const EXCLUDED_TEXT_TAGS = new Set(['STYLE', 'SCRIPT', 'NOSCRIPT', 'TEMPLATE', 'SVG']);
+
+        function getCleanTextContent(el, maxLength) {
+          if (EXCLUDED_TEXT_TAGS.has(el.tagName.toUpperCase())) {
+            return '';
+          }
+
+          const walker = document.createTreeWalker(el, 4, { // NodeFilter.SHOW_TEXT = 4
+            acceptNode: function(node) {
+              let parent = node.parentElement;
+              while (parent && parent !== el) {
+                if (EXCLUDED_TEXT_TAGS.has(parent.tagName.toUpperCase())) {
+                  return 2; // FILTER_REJECT
+                }
+                parent = parent.parentElement;
+              }
+              if (node.parentElement && EXCLUDED_TEXT_TAGS.has(node.parentElement.tagName.toUpperCase())) {
+                return 2;
+              }
+              return 1; // FILTER_ACCEPT
+            }
+          });
+
+          const textParts = [];
+          let totalLength = 0;
+          let node;
+
+          while ((node = walker.nextNode()) && totalLength < maxLength) {
+            const text = node.nodeValue;
+            if (text) {
+              const trimmed = text.trim();
+              if (trimmed) {
+                textParts.push(trimmed);
+                totalLength += trimmed.length;
+              }
+            }
+          }
+
+          return textParts.join(' ').substring(0, maxLength);
+        }
+
+        window.__testGetCleanTextContent = getCleanTextContent;
+      `;
+
+      eval(extractedFunction);
+
+      getCleanTextContent = (window as unknown as { __testGetCleanTextContent: typeof getCleanTextContent }).__testGetCleanTextContent;
+    });
+
+    it('should extract text content from simple elements', () => {
+      const div = document.createElement('div');
+      div.textContent = 'Hello world';
+
+      const result = getCleanTextContent(div, 100);
+      expect(result).toBe('Hello world');
+    });
+
+    it('should exclude style tag content', () => {
+      const div = document.createElement('div');
+      div.innerHTML = `
+        <span>Hello world</span>
+        <style>.some-class { color: red; }</style>
+      `;
+
+      const result = getCleanTextContent(div, 100);
+      expect(result).toBe('Hello world');
+      expect(result).not.toContain('.some-class');
+      expect(result).not.toContain('color');
+    });
+
+    it('should exclude script tag content', () => {
+      const div = document.createElement('div');
+      div.innerHTML = `
+        <p>Important message</p>
+        <script>console.log('executed');</script>
+      `;
+
+      const result = getCleanTextContent(div, 100);
+      expect(result).toBe('Important message');
+      expect(result).not.toContain('console');
+      expect(result).not.toContain('executed');
+    });
+
+    it('should exclude noscript tag content', () => {
+      const div = document.createElement('div');
+      div.innerHTML = `
+        <span>Main content</span>
+        <noscript>JavaScript is disabled</noscript>
+      `;
+
+      const result = getCleanTextContent(div, 100);
+      expect(result).toBe('Main content');
+      expect(result).not.toContain('JavaScript is disabled');
+    });
+
+    it('should exclude template tag content', () => {
+      const div = document.createElement('div');
+      div.innerHTML = `
+        <span>Visible content</span>
+        <template>Template content</template>
+      `;
+
+      const result = getCleanTextContent(div, 100);
+      expect(result).toBe('Visible content');
+      expect(result).not.toContain('Template content');
+    });
+
+    it('should exclude SVG text content', () => {
+      const div = document.createElement('div');
+      div.innerHTML = '<span>Regular text</span>';
+      // Create SVG element properly for jsdom
+      const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+      const svgText = document.createElementNS('http://www.w3.org/2000/svg', 'text');
+      svgText.textContent = 'SVG text';
+      svg.appendChild(svgText);
+      div.appendChild(svg);
+
+      const result = getCleanTextContent(div, 100);
+      expect(result).toBe('Regular text');
+      expect(result).not.toContain('SVG text');
+    });
+
+    it('should handle CSS-in-JS injected styles (original bug)', () => {
+      // This is the exact scenario from the bug report
+      const div = document.createElement('div');
+      div.innerHTML = `
+        <span>harleen deol retired out</span>
+        <style>.MagqMc .ZFiwCf{background-color:#fff;border:1px solid #dadce0}</style>
+      `;
+
+      const result = getCleanTextContent(div, 200);
+      expect(result).toBe('harleen deol retired out');
+      expect(result).not.toContain('MagqMc');
+      expect(result).not.toContain('background-color');
+      expect(result).not.toContain('#fff');
+    });
+
+    it('should handle nested style tags inside other elements', () => {
+      const div = document.createElement('div');
+      div.innerHTML = `
+        <div>
+          <span>First text</span>
+          <div>
+            <style>.nested { display: none; }</style>
+            <span>Second text</span>
+          </div>
+        </div>
+      `;
+
+      const result = getCleanTextContent(div, 100);
+      expect(result).toBe('First text Second text');
+      expect(result).not.toContain('.nested');
+      expect(result).not.toContain('display');
+    });
+
+    it('should handle multiple excluded tags', () => {
+      const div = document.createElement('div');
+      div.innerHTML = `
+        <span>Clean text</span>
+        <style>.css { color: blue; }</style>
+        <script>var x = 1;</script>
+        <noscript>No JS</noscript>
+      `;
+
+      const result = getCleanTextContent(div, 100);
+      expect(result).toBe('Clean text');
+    });
+
+    it('should respect maxLength parameter', () => {
+      const div = document.createElement('div');
+      div.textContent = 'This is a very long text that should be truncated';
+
+      const result = getCleanTextContent(div, 20);
+      expect(result.length).toBeLessThanOrEqual(20);
+      expect(result).toBe('This is a very long ');
+    });
+
+    it('should return empty string for style elements', () => {
+      const style = document.createElement('style');
+      style.textContent = '.class { color: red; }';
+
+      const result = getCleanTextContent(style, 100);
+      expect(result).toBe('');
+    });
+
+    it('should return empty string for script elements', () => {
+      const script = document.createElement('script');
+      script.textContent = 'console.log("test");';
+
+      const result = getCleanTextContent(script, 100);
+      expect(result).toBe('');
+    });
+
+    it('should join text from multiple text nodes with spaces', () => {
+      const div = document.createElement('div');
+      div.innerHTML = '<span>First</span> <span>Second</span> <span>Third</span>';
+
+      const result = getCleanTextContent(div, 100);
+      expect(result).toBe('First Second Third');
+    });
+
+    it('should handle empty elements', () => {
+      const div = document.createElement('div');
+
+      const result = getCleanTextContent(div, 100);
+      expect(result).toBe('');
+    });
+
+    it('should handle elements with only whitespace', () => {
+      const div = document.createElement('div');
+      div.innerHTML = '   \n\t   ';
+
+      const result = getCleanTextContent(div, 100);
+      expect(result).toBe('');
+    });
+
+    it('should handle deeply nested content', () => {
+      const div = document.createElement('div');
+      div.innerHTML = `
+        <div>
+          <div>
+            <div>
+              <span>Deep content</span>
+              <style>.deep { margin: 0; }</style>
+            </div>
+          </div>
+        </div>
+      `;
+
+      const result = getCleanTextContent(div, 100);
+      expect(result).toBe('Deep content');
+      expect(result).not.toContain('.deep');
+    });
+  });
+
+  describe('script contains getCleanTextContent', () => {
+    it('should include getCleanTextContent function', () => {
+      expect(OBSERVATION_OBSERVER_SCRIPT).toContain('getCleanTextContent');
+    });
+
+    it('should include EXCLUDED_TEXT_TAGS set', () => {
+      expect(OBSERVATION_OBSERVER_SCRIPT).toContain('EXCLUDED_TEXT_TAGS');
+    });
+
+    it('should use getCleanTextContent in computeSignals', () => {
+      // Verify the script uses getCleanTextContent instead of el.textContent directly
+      // in the computeSignals function
+      expect(OBSERVATION_OBSERVER_SCRIPT).toContain('getCleanTextContent(el');
+    });
+
+    it('should use getCleanTextContent in captureEntry', () => {
+      // Verify the script uses getCleanTextContent in captureEntry function
+      expect(OBSERVATION_OBSERVER_SCRIPT).toContain('getCleanTextContent(el, MAX_TEXT_LENGTH)');
+    });
+  });
+});

--- a/tests/unit/state/diff-engine.test.ts
+++ b/tests/unit/state/diff-engine.test.ts
@@ -727,9 +727,9 @@ describe('Diff Engine', () => {
       expect(result.diff.mutations.statusAppeared[0].role).toBe('log');
     });
 
-    it('should track all readable elements when TRACK_ALL_READABLE_MUTATIONS is true', () => {
-      // With TRACK_ALL_READABLE_MUTATIONS flag enabled, paragraphs are tracked
-      // Note: This test documents current evaluation mode behavior
+    it('should NOT track non-status readable elements when TRACK_ALL_READABLE_MUTATIONS is false', () => {
+      // With TRACK_ALL_READABLE_MUTATIONS flag disabled, only ARIA status roles are tracked
+      // Paragraphs, headings, and other non-status readable elements are ignored
       const paragraph = createNode({
         kind: 'paragraph',
         label: 'Some dynamic text',
@@ -742,10 +742,8 @@ describe('Diff Engine', () => {
 
       const result = computeDiff(prev, curr);
 
-      // With flag enabled, paragraphs ARE tracked (evaluation mode)
-      expect(result.diff.mutations.statusAppeared).toHaveLength(1);
-      expect(result.diff.mutations.statusAppeared[0].role).toBe('paragraph');
-      expect(result.diff.mutations.statusAppeared[0].text).toBe('Some dynamic text');
+      // With flag disabled, paragraphs are NOT tracked
+      expect(result.diff.mutations.statusAppeared).toHaveLength(0);
     });
 
     it('should truncate long text in mutations', () => {

--- a/tests/unit/tools/execute-action.test.ts
+++ b/tests/unit/tools/execute-action.test.ts
@@ -39,6 +39,7 @@ vi.mock('../../../src/observation/index.js', () => ({
     getAccumulatedObservations: vi.fn().mockResolvedValue({ duringAction: [], sincePrevious: [] }),
     inject: vi.fn().mockResolvedValue(undefined),
     reset: vi.fn().mockResolvedValue(undefined),
+    filterBySignificance: vi.fn().mockImplementation((obs) => obs),
   },
 }));
 

--- a/tests/unit/tools/execute-action.test.ts
+++ b/tests/unit/tools/execute-action.test.ts
@@ -39,7 +39,7 @@ vi.mock('../../../src/observation/index.js', () => ({
     getAccumulatedObservations: vi.fn().mockResolvedValue({ duringAction: [], sincePrevious: [] }),
     inject: vi.fn().mockResolvedValue(undefined),
     reset: vi.fn().mockResolvedValue(undefined),
-    filterBySignificance: vi.fn().mockImplementation((obs) => obs),
+    filterBySignificance: vi.fn().mockImplementation(<T>(obs: T): T => obs),
   },
 }));
 


### PR DESCRIPTION
## Summary

- Disable `TRACK_ALL_READABLE_MUTATIONS` flag to only track ARIA status roles (status, alert, log, progressbar) instead of all readable nodes like paragraphs and headings
- Add observation filtering with threshold 5 before attaching to snapshots, requiring semantic signals (ARIA roles) or temporal signals (delay)
- Raise default `SIGNIFICANCE_THRESHOLD` from 3 to 4 for stricter browser-side filtering
- Fix CSS/JS content pollution in DOM mutation text extraction using TreeWalker

This significantly reduces noise in action responses by filtering out trivial text mutations and low-significance DOM observations.

## Test plan

- [x] All unit tests pass (1266 tests)
- [x] Type-check passes
- [x] Lint passes
- [x] Manual testing with non-headless browser verified cleaner action responses

🤖 Generated with [Claude Code](https://claude.ai/code)