### PR TITLE
ci: add separate workflow for integration tests with Playwright

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - develop
+      - 'feat/**'
       - 'feature/**'
   pull_request:
     branches:
@@ -21,6 +22,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # Node 20.x only - browser tests don't need multi-version matrix
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
@@ -29,6 +31,15 @@ jobs:
 
       - name: Install dependencies
         run: npm ci
+
+      - name: Type check
+        run: npm run type-check
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-chromium
 
       - name: Install Playwright browsers
         run: npx playwright install --with-deps chromium

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -1,0 +1,39 @@
+name: Integration Tests
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - 'feature/**'
+  pull_request:
+    branches:
+      - main
+      - develop
+  workflow_dispatch: # Allow manual triggering
+
+jobs:
+  integration-test:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run integration tests
+        run: npm run test:integration
+        env:
+          RUN_INTEGRATION: 'true'

--- a/tests/integration/network-idle.test.ts
+++ b/tests/integration/network-idle.test.ts
@@ -42,7 +42,7 @@ const DELAYED_FETCH_HTML = `
 `;
 
 // Skip in CI unless RUN_INTEGRATION is set (for dedicated integration workflow)
-const skipIntegration = process.env.CI === 'true' && !process.env.RUN_INTEGRATION;
+const skipIntegration = process.env.CI === 'true' && process.env.RUN_INTEGRATION !== 'true';
 
 describe.skipIf(skipIntegration)('Network Idle Stabilization (Integration)', () => {
   let server: Server;

--- a/tests/integration/network-idle.test.ts
+++ b/tests/integration/network-idle.test.ts
@@ -41,10 +41,10 @@ const DELAYED_FETCH_HTML = `
 </html>
 `;
 
-// Skip in CI - Playwright browsers not installed in CI environment
-const isCI = process.env.CI === 'true';
+// Skip in CI unless RUN_INTEGRATION is set (for dedicated integration workflow)
+const skipIntegration = process.env.CI === 'true' && !process.env.RUN_INTEGRATION;
 
-describe.skipIf(isCI)('Network Idle Stabilization (Integration)', () => {
+describe.skipIf(skipIntegration)('Network Idle Stabilization (Integration)', () => {
   let server: Server;
   let port: number;
   let browser: Browser;

--- a/tests/integration/observation-capture.test.ts
+++ b/tests/integration/observation-capture.test.ts
@@ -18,7 +18,7 @@ import { chromium, Browser, Page } from 'playwright';
 import { observationAccumulator } from '../../src/observation/index.js';
 
 // Skip in CI unless RUN_INTEGRATION is set (for dedicated integration workflow)
-const skipIntegration = !!process.env.CI && !process.env.RUN_INTEGRATION;
+const skipIntegration = process.env.CI === 'true' && process.env.RUN_INTEGRATION !== 'true';
 
 describe.skipIf(skipIntegration)('Observation Capture Integration', () => {
   let browser: Browser;

--- a/tests/integration/observation-capture.test.ts
+++ b/tests/integration/observation-capture.test.ts
@@ -17,9 +17,10 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { chromium, Browser, Page } from 'playwright';
 import { observationAccumulator } from '../../src/observation/index.js';
 
-const isCI = !!process.env.CI;
+// Skip in CI unless RUN_INTEGRATION is set (for dedicated integration workflow)
+const skipIntegration = !!process.env.CI && !process.env.RUN_INTEGRATION;
 
-describe.skipIf(isCI)('Observation Capture Integration', () => {
+describe.skipIf(skipIntegration)('Observation Capture Integration', () => {
   let browser: Browser;
   let page: Page;
 


### PR DESCRIPTION
## Summary
- Add dedicated `integration-test.yml` workflow that installs Playwright browsers
- Update integration test skip logic to allow forcing execution via `RUN_INTEGRATION` env var
- Browser-based tests (observation-capture, network-idle) now run in the new workflow

## Test plan
- [ ] Verify CI workflow still passes (browser tests self-skip)
- [ ] Verify Integration Tests workflow runs and passes with real browsers

🤖 Generated with [Claude Code](https://claude.com/claude-code)