### PR TITLE
feat: Chrome 144+ autoConnect and observation XML format optimization

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,30 @@ See the `examples/` directory for concrete agent workflows.
 
 ---
 
+## Using Your Existing Chrome Profile (Chrome 144+)
+
+To connect with your bookmarks, extensions, and logged-in sessions:
+
+1. Navigate to `chrome://inspect/#remote-debugging` in Chrome
+2. Enable remote debugging and allow the connection
+3. Set `AUTO_CONNECT=true` in your MCP config and use `connect_browser`
+
+```json
+{
+  "mcpServers": {
+    "athena-browser-mcp": {
+      "command": "node",
+      "args": ["/path/to/athena-browser-mcp/dist/src/index.js"],
+      "env": {
+        "AUTO_CONNECT": "true"
+      }
+    }
+  }
+}
+```
+
+---
+
 ## Installation
 
 ```bash

--- a/src/observation/observation.types.ts
+++ b/src/observation/observation.types.ts
@@ -105,6 +105,19 @@ export interface ObservedContent {
 }
 
 /**
+ * Child element within an observation.
+ * Represents actionable or notable elements inside an observed container.
+ */
+export interface ObservationChild {
+  /** Element type: 'button', 'link', 'heading', 'text', etc. */
+  tag: string;
+  /** Element identifier for targeting (if available) */
+  eid?: string;
+  /** Visible text content */
+  text: string;
+}
+
+/**
  * A single DOM observation - an element that appeared or disappeared.
  */
 export interface DOMObservation {
@@ -136,6 +149,12 @@ export interface DOMObservation {
 
   /** Shadow DOM path - identifiers of shadow host ancestors (for shadow DOM observations) */
   shadowPath?: string[];
+
+  /** Interactive/notable children within this observation (for appeared elements) */
+  children?: ObservationChild[];
+
+  /** Delay in ms from action start to when this element appeared */
+  delayMs?: number;
 }
 
 /**

--- a/src/tools/browser-tools.ts
+++ b/src/tools/browser-tools.ts
@@ -418,6 +418,9 @@ export async function connectBrowser(
 
   if (input.endpoint_url) {
     await session.connect({ endpointUrl: input.endpoint_url });
+  } else if (process.env.AUTO_CONNECT === 'true') {
+    // Chrome 144+ auto-connect via DevToolsActivePort
+    await session.connect({ autoConnect: true });
   } else {
     await session.connect();
   }

--- a/tests/unit/observation/eid-linker.test.ts
+++ b/tests/unit/observation/eid-linker.test.ts
@@ -626,7 +626,10 @@ describe('computeMatchScore empty text/label scenarios', () => {
 // extractObservationChildren Tests
 // ============================================================================
 
-import { extractObservationChildren } from '../../../src/observation/eid-linker.js';
+import {
+  extractObservationChildren,
+  buildInteractiveNodeList,
+} from '../../../src/observation/eid-linker.js';
 
 describe('extractObservationChildren', () => {
   it('should extract interactive children from matched container', () => {
@@ -654,8 +657,9 @@ describe('extractObservationChildren', () => {
 
     const snapshot = createSnapshot([containerNode, buttonNode, linkNode]);
     const registry = createMockRegistry({ 2: 'btn-submit', 3: 'link-forgot' });
+    const interactiveNodes = buildInteractiveNodeList(snapshot);
 
-    const children = extractObservationChildren(containerNode, snapshot, registry);
+    const children = extractObservationChildren(containerNode, interactiveNodes, registry);
 
     expect(children).toHaveLength(2);
     expect(children[0]).toEqual({ tag: 'button', eid: 'btn-submit', text: 'Submit' });
@@ -678,8 +682,9 @@ describe('extractObservationChildren', () => {
 
     const snapshot = createSnapshot([containerNode, headingNode]);
     const registry = createMockRegistry({ 2: 'heading-cart' });
+    const interactiveNodes = buildInteractiveNodeList(snapshot);
 
-    const children = extractObservationChildren(containerNode, snapshot, registry);
+    const children = extractObservationChildren(containerNode, interactiveNodes, registry);
 
     expect(children).toHaveLength(1);
     expect(children[0]).toEqual({ tag: 'heading', eid: 'heading-cart', text: 'My Cart' });
@@ -709,8 +714,9 @@ describe('extractObservationChildren', () => {
 
     const snapshot = createSnapshot([containerNode, outsideButton, insideButton]);
     const registry = createMockRegistry({ 2: 'btn-outside', 3: 'btn-inside' });
+    const interactiveNodes = buildInteractiveNodeList(snapshot);
 
-    const children = extractObservationChildren(containerNode, snapshot, registry);
+    const children = extractObservationChildren(containerNode, interactiveNodes, registry);
 
     expect(children).toHaveLength(1);
     expect(children[0].text).toBe('Inside');
@@ -739,8 +745,9 @@ describe('extractObservationChildren', () => {
       childNodes.map((n, i) => [n.backend_node_id, `btn-${i + 1}`])
     );
     const registry = createMockRegistry(eidMap);
+    const interactiveNodes = buildInteractiveNodeList(snapshot);
 
-    const children = extractObservationChildren(containerNode, snapshot, registry);
+    const children = extractObservationChildren(containerNode, interactiveNodes, registry);
 
     expect(children).toHaveLength(5);
   });
@@ -767,8 +774,9 @@ describe('extractObservationChildren', () => {
 
     const snapshot = createSnapshot([containerNode, emptyButton, labeledButton]);
     const registry = createMockRegistry({ 2: 'btn-empty', 3: 'btn-click' });
+    const interactiveNodes = buildInteractiveNodeList(snapshot);
 
-    const children = extractObservationChildren(containerNode, snapshot, registry);
+    const children = extractObservationChildren(containerNode, interactiveNodes, registry);
 
     expect(children).toHaveLength(1);
     expect(children[0].text).toBe('Click Me');
@@ -805,8 +813,9 @@ describe('extractObservationChildren', () => {
 
     const snapshot = createSnapshot([containerNode, textNode, sectionNode, buttonNode]);
     const registry = createMockRegistry({ 2: 'text-1', 3: 'section-1', 4: 'btn-ok' });
+    const interactiveNodes = buildInteractiveNodeList(snapshot);
 
-    const children = extractObservationChildren(containerNode, snapshot, registry);
+    const children = extractObservationChildren(containerNode, interactiveNodes, registry);
 
     expect(children).toHaveLength(1);
     expect(children[0]).toEqual({ tag: 'button', eid: 'btn-ok', text: 'OK' });
@@ -822,8 +831,9 @@ describe('extractObservationChildren', () => {
 
     const snapshot = createSnapshot([containerNode]);
     const registry = createMockRegistry({});
+    const interactiveNodes = buildInteractiveNodeList(snapshot);
 
-    const children = extractObservationChildren(containerNode, snapshot, registry);
+    const children = extractObservationChildren(containerNode, interactiveNodes, registry);
 
     expect(children).toHaveLength(0);
   });
@@ -845,8 +855,9 @@ describe('extractObservationChildren', () => {
     const snapshot = createSnapshot([containerNode, buttonNode]);
     // Registry returns undefined for backend_node_id 2
     const registry = createMockRegistry({});
+    const interactiveNodes = buildInteractiveNodeList(snapshot);
 
-    const children = extractObservationChildren(containerNode, snapshot, registry);
+    const children = extractObservationChildren(containerNode, interactiveNodes, registry);
 
     expect(children).toHaveLength(1);
     expect(children[0].eid).toBeUndefined();
@@ -903,8 +914,9 @@ describe('extractObservationChildren', () => {
       5: 'input-1',
       6: 'checkbox-1',
     });
+    const interactiveNodes = buildInteractiveNodeList(snapshot);
 
-    const children = extractObservationChildren(containerNode, snapshot, registry);
+    const children = extractObservationChildren(containerNode, interactiveNodes, registry);
 
     expect(children).toHaveLength(5);
     expect(children.map((c) => c.tag)).toEqual(['button', 'link', 'heading', 'input', 'checkbox']);


### PR DESCRIPTION
## Summary

- Add Chrome 144+ auto-connect support via DevToolsActivePort file reading
- Optimize observation XML representation for token efficiency (flattened format)

## Changes

### Chrome 144+ Auto-Connect

Enables connecting to an existing Chrome instance with UI-based remote debugging enabled:

- Reads `DevToolsActivePort` file from Chrome's user data directory
- Cross-platform support (macOS, Windows, Linux)
- New `AUTO_CONNECT=true` environment variable for MCP config

**Usage:**
1. Navigate to `chrome://inspect/#remote-debugging` in Chrome
2. Enable remote debugging
3. Set `AUTO_CONNECT=true` in MCP config

### Observation XML Optimization

Flattens the observation XML output to reduce token consumption:

- Replaced `<during_action>` / `<since_previous>` wrappers with `when="action"` / `when="prior"` attributes
- Removed `<mutations>` wrapper - mutations now inline in `<diff>` element
- Added observation children extraction for interactive elements within containers
- Self-closing `<diff />` tags when no mutations present

**Before:**
```xml
<observations>
  <during_action>
    <appeared significance="5">
      <signals semantic="dialog" />
      <content tag="div" role="dialog">Modal</content>
    </appeared>
  </during_action>
</observations>
```

**After:**
```xml
<observations>
  <appeared when="action" eid="dialog-001" role="dialog">
    <heading eid="dlg-title">My Cart</heading>
    <button eid="btn-close">Close</button>
  </appeared>
</observations>
```

## Files Modified

```
src/browser/session-manager.ts    # Auto-connect implementation
src/tools/browser-tools.ts        # AUTO_CONNECT env var support
src/observation/eid-linker.ts     # Child extraction for observations
src/observation/observation.types.ts  # ObservationChild type
src/state/state-renderer.ts       # Flattened XML format
README.md                         # Documentation for auto-connect
```

## Test Plan

- [x] Unit tests for extractObservationChildren (8 tests)
- [x] Updated state-renderer tests for new XML format
- [x] Updated eid-linker tests for layout bbox format
- [x] TypeScript type check passes
- [x] ESLint passes

## Breaking Changes

⚠️ **XML Format Change**: The observation and diff XML format has changed. Consumers parsing this XML will need to update their parsing logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)