### PR TITLE
fix: use single quotes for XML attributes containing double quotes

### DIFF
--- a/src/lib/text-utils.ts
+++ b/src/lib/text-utils.ts
@@ -440,3 +440,33 @@ export function getTextContent(
   const result = normalizeText(parts.join(' '));
   return result || undefined;
 }
+
+/**
+ * Build an XML attribute string, choosing quote style to minimize escaping.
+ * Uses single quotes when value contains double quotes (common in selectors).
+ *
+ * @param name - Attribute name
+ * @param value - Attribute value
+ * @returns Formatted attribute string like `name="value"` or `name='value'`
+ */
+export function xmlAttr(name: string, value: string): string {
+  if (!value) return `${name}=""`;
+
+  const hasDoubleQuote = value.includes('"');
+  const hasSingleQuote = value.includes("'");
+
+  // Prefer single quotes when value contains double quotes (common in selectors)
+  if (hasDoubleQuote && !hasSingleQuote) {
+    const escaped = value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    return `${name}='${escaped}'`;
+  }
+
+  // Default: double-quote wrapping with full escaping
+  const escaped = value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+  return `${name}="${escaped}"`;
+}

--- a/src/tools/response-builder.ts
+++ b/src/tools/response-builder.ts
@@ -10,6 +10,7 @@ import type { BaseSnapshot, NodeState } from '../snapshot/snapshot.types.js';
 import { getStateManager } from './execute-action.js';
 import type { StateResponse } from '../state/types.js';
 import type { NodeDetails } from './tool-schemas.js';
+import { xmlAttr } from '../lib/text-utils.js';
 
 // ============================================================================
 // XML Utilities
@@ -246,9 +247,9 @@ export function buildGetNodeDetailsResponse(
 
   // Find (locator strategies)
   if (node.find) {
-    const findAttrs = [`primary="${escapeXml(node.find.primary)}"`];
+    const findAttrs = [xmlAttr('primary', node.find.primary)];
     if (node.find.alternates && node.find.alternates.length > 0) {
-      findAttrs.push(`alternates="${escapeXml(node.find.alternates.join(';'))}"`);
+      findAttrs.push(xmlAttr('alternates', node.find.alternates.join(';')));
     }
     lines.push(`    <find ${findAttrs.join(' ')} />`);
   }

--- a/tests/unit/lib/xml-attr.test.ts
+++ b/tests/unit/lib/xml-attr.test.ts
@@ -1,0 +1,34 @@
+import { describe, it, expect } from 'vitest';
+import { xmlAttr } from '../../../src/lib/text-utils.js';
+
+describe('xmlAttr', () => {
+  it('should use single quotes when value contains double quotes', () => {
+    const result = xmlAttr('primary', 'role=button[name="Shopping Bag"]');
+    expect(result).toBe(`primary='role=button[name="Shopping Bag"]'`);
+    expect(result).not.toContain('&quot;');
+  });
+
+  it('should use double quotes for simple values', () => {
+    const result = xmlAttr('id', 'submit-btn');
+    expect(result).toBe('id="submit-btn"');
+  });
+
+  it('should escape < > & in single-quoted values', () => {
+    const result = xmlAttr('test', 'a < b & c > d "quoted"');
+    expect(result).toBe(`test='a &lt; b &amp; c &gt; d "quoted"'`);
+  });
+
+  it('should handle values with both quote types using double quotes', () => {
+    const result = xmlAttr('test', `He said "it's fine"`);
+    expect(result).toBe(`test="He said &quot;it&apos;s fine&quot;"`);
+  });
+
+  it('should handle empty values', () => {
+    expect(xmlAttr('empty', '')).toBe('empty=""');
+  });
+
+  it('should handle values with only single quotes using double quotes', () => {
+    const result = xmlAttr('test', "it's a test");
+    expect(result).toBe(`test="it&apos;s a test"`);
+  });
+});


### PR DESCRIPTION
## Summary

- Improves readability of locator strings in XML output by using single quotes when the value contains double quotes
- Prevents HTML entity escaping (`&quot;`) which reduced readability for LLMs consuming the output

**Before:**
```xml
<find primary="role=button[name=&quot;Shopping Bag&quot;]" alternates="..." />
```

**After:**
```xml
<find primary='role=button[name="Shopping Bag"]' alternates='...' />
```

## Changes

- Add `xmlAttr()` utility function to `src/lib/text-utils.ts` for smart quote selection
- Update `src/tools/response-builder.ts` to use `xmlAttr` for `<find>` element attributes
- Add comprehensive unit tests in `tests/unit/lib/xml-attr.test.ts`

## Test plan

- [x] Unit tests pass for new `xmlAttr()` function
- [x] All existing tests pass (1406 tests)
- [x] Type check passes
- [x] Lint passes
- [x] Manual verification with apple.com - `<find>` elements render with readable quotes

🤖 Generated with [Claude Code](https://claude.com/claude-code)