### PR TITLE
feat: add list_tabs tool for tab discovery

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,6 +21,7 @@ import {
   initializeTools,
   initializeFormTools,
   // Tool handlers
+  listTabs,
   closePage,
   closeSession,
   navigate,
@@ -40,6 +41,7 @@ import {
   getFormUnderstanding,
   getFieldContext,
   // Input schemas only (all outputs are XML strings now)
+  ListTabsInputSchema,
   ClosePageInputSchema,
   CloseSessionInputSchema,
   NavigateInputSchema,
@@ -121,6 +123,17 @@ function initializeServer(): BrowserAutomationServer {
   // ============================================================================
   // SESSION TOOLS
   // ============================================================================
+
+  server.registerTool(
+    'list_tabs',
+    {
+      title: 'List Tabs',
+      description:
+        'List all open browser tabs with their page_id, URL, and title. Use page_id to target a specific tab in other tools.',
+      inputSchema: ListTabsInputSchema.shape,
+    },
+    withLazyInit(listTabs, 'list_tabs')
+  );
 
   server.registerTool(
     'close_page',

--- a/src/tools/browser-tools.ts
+++ b/src/tools/browser-tools.ts
@@ -62,6 +62,7 @@ import type { RuntimeHealth } from '../state/health.types.js';
 import {
   buildClosePageResponse,
   buildCloseSessionResponse,
+  buildListTabsResponse,
   buildFindElementsResponse,
   buildGetNodeDetailsResponse,
   type FindElementsMatch,
@@ -375,6 +376,22 @@ async function executeNavigationAction(
 // ============================================================================
 // SIMPLIFIED API - Tool handlers with clearer contracts
 // ============================================================================
+
+/**
+ * List all open browser tabs with their metadata.
+ *
+ * @returns XML result with tab list
+ */
+export function listTabs(): import('./tool-schemas.js').ListTabsOutput {
+  const session = getSessionManager();
+  const pages = session.listPages();
+  const tabs = pages.map((h) => ({
+    page_id: h.page_id,
+    url: h.url ?? '',
+    title: h.title ?? '',
+  }));
+  return buildListTabsResponse(tabs);
+}
 
 /**
  * Close a specific page.

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -8,6 +8,7 @@ export { initializeTools, getSnapshotStore } from './browser-tools.js';
 
 // Tool handlers - Simplified API
 export {
+  listTabs,
   closePage,
   closeSession,
   navigate,
@@ -31,6 +32,11 @@ export { ensureBrowserForTools, getSessionManager } from '../server/server-confi
 
 // Schemas - Simplified API
 export {
+  // list_tabs
+  ListTabsInputSchema,
+  ListTabsOutputSchema,
+  type ListTabsInput,
+  type ListTabsOutput,
   // close_page
   ClosePageInputSchema,
   ClosePageOutputSchema,

--- a/src/tools/response-builder.ts
+++ b/src/tools/response-builder.ts
@@ -80,6 +80,34 @@ export function buildErrorResponse(pageId: string, error: Error | string): State
 // ============================================================================
 
 /**
+ * Tab metadata for list_tabs response.
+ */
+export interface TabInfo {
+  page_id: string;
+  url: string;
+  title: string;
+}
+
+/**
+ * Build XML response for list_tabs tool.
+ *
+ * @param tabs - Array of tab metadata
+ * @returns XML result string
+ */
+export function buildListTabsResponse(tabs: TabInfo[]): string {
+  const tabLines = tabs.map(
+    (tab) =>
+      `    <tab page_id="${escapeXml(tab.page_id)}" url="${escapeXml(tab.url)}" title="${escapeXml(tab.title)}" />`
+  );
+
+  return `<result type="list_tabs" status="success">
+  <tabs count="${tabs.length}">
+${tabLines.join('\n')}
+  </tabs>
+</result>`;
+}
+
+/**
  * Build XML response for close_page tool.
  *
  * @param pageId - The page ID that was closed

--- a/src/tools/tool-schemas.ts
+++ b/src/tools/tool-schemas.ts
@@ -405,6 +405,18 @@ export type ClickOutcome = z.infer<typeof ClickOutcomeSchema>;
 // ============================================================================
 
 // ============================================================================
+// list_tabs - List all open browser tabs
+// ============================================================================
+
+export const ListTabsInputSchema = z.object({});
+
+/** Returns XML result string */
+export const ListTabsOutputSchema = z.string();
+
+export type ListTabsInput = z.infer<typeof ListTabsInputSchema>;
+export type ListTabsOutput = z.infer<typeof ListTabsOutputSchema>;
+
+// ============================================================================
 // close_page - Close a specific page
 // ============================================================================
 

--- a/tests/unit/tools/list-tabs.test.ts
+++ b/tests/unit/tools/list-tabs.test.ts
@@ -1,0 +1,170 @@
+/**
+ * list_tabs Tool Tests
+ *
+ * Verifies that listTabs returns correct XML for open tabs.
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { SessionManager } from '../../../src/browser/session-manager.js';
+
+// Mock session manager
+const mockListPages = vi.fn();
+const mockSessionManager = {
+  listPages: mockListPages,
+} as unknown as SessionManager;
+
+vi.mock('../../../src/browser/session-manager.js', () => ({}));
+
+// Mock form dependency tracker (required by browser-tools module)
+vi.mock('../../../src/form/index.js', () => ({
+  getDependencyTracker: vi.fn(() => ({
+    clearPage: vi.fn(),
+    clearAll: vi.fn(),
+  })),
+}));
+
+// Mock snapshot modules that browser-tools imports
+vi.mock('../../../src/snapshot/index.js', () => {
+  const SnapshotStore = class {
+    store = vi.fn();
+    getByPageId = vi.fn();
+    removeByPageId = vi.fn();
+    clear = vi.fn();
+  };
+  return {
+    SnapshotStore,
+    clickByBackendNodeId: vi.fn(),
+    typeByBackendNodeId: vi.fn(),
+    pressKey: vi.fn(),
+    selectOption: vi.fn(),
+    hoverByBackendNodeId: vi.fn(),
+    scrollIntoView: vi.fn(),
+    scrollPage: vi.fn(),
+  };
+});
+
+vi.mock('../../../src/snapshot/snapshot-health.js', () => ({
+  captureWithStabilization: vi.fn(),
+  determineHealthCode: vi.fn(),
+}));
+
+vi.mock('../../../src/observation/index.js', () => ({
+  observationAccumulator: {
+    inject: vi.fn(),
+    getAccumulatedObservations: vi.fn(),
+    filterBySignificance: vi.fn(),
+  },
+}));
+
+vi.mock('../../../src/tools/execute-action.js', () => ({
+  executeAction: vi.fn(),
+  executeActionWithRetry: vi.fn(),
+  executeActionWithOutcome: vi.fn(),
+  stabilizeAfterNavigation: vi.fn(),
+  getStateManager: vi.fn(),
+  removeStateManager: vi.fn(),
+  clearAllStateManagers: vi.fn(),
+}));
+
+vi.mock('../../../src/state/element-identity.js', () => ({
+  computeEid: vi.fn(),
+}));
+
+vi.mock('../../../src/state/health.types.js', () => ({
+  createHealthyRuntime: vi.fn(),
+  createRecoveredCdpRuntime: vi.fn(),
+}));
+
+vi.mock('../../../src/query/query-engine.js', () => ({
+  QueryEngine: vi.fn(),
+}));
+
+import { initializeTools, listTabs } from '../../../src/tools/browser-tools.js';
+
+describe('listTabs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should return empty tabs list when no pages are registered', () => {
+    mockListPages.mockReturnValue([]);
+    initializeTools(mockSessionManager);
+
+    const result = listTabs();
+
+    expect(result).toContain('type="list_tabs"');
+    expect(result).toContain('status="success"');
+    expect(result).toContain('count="0"');
+    expect(result).not.toContain('<tab ');
+  });
+
+  it('should return correct metadata for multiple pages', () => {
+    mockListPages.mockReturnValue([
+      {
+        page_id: 'page-abc',
+        url: 'https://example.com',
+        title: 'Example',
+        page: {},
+        cdp: {},
+        created_at: new Date(),
+      },
+      {
+        page_id: 'page-def',
+        url: 'https://other.com',
+        title: 'Other Site',
+        page: {},
+        cdp: {},
+        created_at: new Date(),
+      },
+    ]);
+    initializeTools(mockSessionManager);
+
+    const result = listTabs();
+
+    expect(result).toContain('count="2"');
+    expect(result).toContain('page_id="page-abc"');
+    expect(result).toContain('url="https://example.com"');
+    expect(result).toContain('title="Example"');
+    expect(result).toContain('page_id="page-def"');
+    expect(result).toContain('url="https://other.com"');
+    expect(result).toContain('title="Other Site"');
+  });
+
+  it('should handle pages with missing url and title', () => {
+    mockListPages.mockReturnValue([
+      {
+        page_id: 'page-new',
+        page: {},
+        cdp: {},
+        created_at: new Date(),
+      },
+    ]);
+    initializeTools(mockSessionManager);
+
+    const result = listTabs();
+
+    expect(result).toContain('count="1"');
+    expect(result).toContain('page_id="page-new"');
+    expect(result).toContain('url=""');
+    expect(result).toContain('title=""');
+  });
+
+  it('should escape XML special characters in tab metadata', () => {
+    mockListPages.mockReturnValue([
+      {
+        page_id: 'page-special',
+        url: 'https://example.com?foo=1&bar=2',
+        title: 'Test <Page> & "Stuff"',
+        page: {},
+        cdp: {},
+        created_at: new Date(),
+      },
+    ]);
+    initializeTools(mockSessionManager);
+
+    const result = listTabs();
+
+    expect(result).toContain('&amp;');
+    expect(result).toContain('&lt;Page&gt;');
+    expect(result).toContain('&quot;Stuff&quot;');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds new `list_tabs` MCP tool that returns all open browser tabs with metadata (page_id, URL, title)
- Enables agents to discover available tabs and use page_id to target specific tabs in other tools
- Includes unit tests covering empty list, multiple pages, missing optional fields, and XML escaping

## Test plan
- [x] Run `npm run check` (type-check, lint, format, tests) — all pass
- [x] Verify `npx vitest run tests/unit/tools/list-tabs.test.ts` — 4 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)