### PR TITLE
fix(cdp): check expected failures before marking session inactive

### DIFF
--- a/tests/unit/cdp/puppeteer-cdp-client.test.ts
+++ b/tests/unit/cdp/puppeteer-cdp-client.test.ts
@@ -482,5 +482,18 @@ describe('PuppeteerCdpClient', () => {
 
       expect(client.isActive()).toBe(true);
     });
+
+    it('should treat Accessibility.getFullAXTree failure for removed frame as expected', async () => {
+      mockSend
+        .mockResolvedValueOnce({}) // Accessibility.enable
+        .mockRejectedValueOnce(new Error('Frame with the given frameId is not found'));
+
+      await expect(
+        client.send('Accessibility.getFullAXTree', { frameId: 'removed-frame' })
+      ).rejects.toThrow('Frame with the given frameId is not found');
+
+      // Session should still be active (expected failure for cross-origin/removed frames)
+      expect(client.isActive()).toBe(true);
+    });
   });
 });


### PR DESCRIPTION
## Summary

- Fixed error handling order in `PuppeteerCdpClient.send()` to check expected failures BEFORE evaluating session death conditions
- Prevents expected failures (like cross-origin frame AX extraction) from incorrectly marking the CDP session as inactive
- Added test for `Accessibility.getFullAXTree` expected failure case

## Problem

When extracting accessibility trees from multiple frames (e.g., Google with 17 frames), some frames fail with expected errors like "Frame with the given frameId is not found". The previous code would evaluate `isSessionDead` first, which could mark the session inactive even for expected failures, causing subsequent layout extraction to fail.

## Solution

Reordered the error handling to:
1. Check `isExpectedFailure` FIRST
2. Only evaluate `isSessionDead` for unexpected failures
3. Expected failures are logged at debug level and don't affect session state

## Test plan

- [x] Unit tests pass (41 tests in puppeteer-cdp-client.test.ts)
- [x] New test added for Accessibility.getFullAXTree expected failure
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.ai/code)