### PR TITLE
feat(diagnostics): add CDP event logging and page health diagnostics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,21 @@ Orchestrates modular extractors to build BaseSnapshot:
 
 EIDs computed from semantic hash of: role, accessible name, landmark path, position hint, layer context. Survives DOM mutations.
 
+### Diagnostics (`src/diagnostics/`)
+
+Tools for debugging snapshot failures:
+
+- `CdpEventLogger`: Captures CDP events during operations for post-mortem analysis
+- `checkPageHealth()`: Collects page state (title, content, frame status) to diagnose issues
+
+Use diagnostics when snapshot returns empty:
+1. Enable with `includeDiagnostics: true` in capture options
+2. Check `result.diagnostics.pageHealth` for indicators
+3. Common indicators:
+   - `empty_title`: Page didn't fully load (navigation issue)
+   - `empty_content`: Content inaccessible via CDP (execution context issue)
+   - `content_error`: Exception when reading content (page crashed/navigated)
+
 ## Directory Structure
 
 ```
@@ -138,6 +153,10 @@ src/
 │   └── xml-renderer.ts          # XML output rendering
 ├── delta/
 │   └── dom-stabilizer.ts        # Stabilize DOM after actions
+├── diagnostics/
+│   ├── index.ts                 # Module exports
+│   ├── cdp-event-logger.ts      # CDP event capture for debugging
+│   └── page-health.ts           # Page state diagnostics
 ├── lib/                         # Reusable algorithms
 └── shared/                      # Types, services, errors
 

--- a/src/diagnostics/cdp-event-logger.ts
+++ b/src/diagnostics/cdp-event-logger.ts
@@ -1,0 +1,117 @@
+/**
+ * CDP Event Logger
+ *
+ * Captures CDP events for post-mortem analysis of snapshot failures.
+ * Tracks navigation lifecycle, execution contexts, and errors.
+ */
+
+import type { CdpClient } from '../cdp/cdp-client.interface.js';
+
+/** Single captured CDP event */
+export interface CdpEventEntry {
+  event: string;
+  params: unknown;
+  localTimestamp: number;
+}
+
+/** Events we want to capture for diagnostics */
+const DIAGNOSTIC_EVENTS = [
+  // Navigation lifecycle
+  'Page.frameNavigated',
+  'Page.frameStartedLoading',
+  'Page.frameStoppedLoading',
+  'Page.loadEventFired',
+  'Page.domContentEventFired',
+  'Page.navigatedWithinDocument',
+  // Execution contexts
+  'Runtime.executionContextCreated',
+  'Runtime.executionContextDestroyed',
+  'Runtime.executionContextsCleared',
+  // Errors
+  'Page.javascriptDialogOpening',
+  'Inspector.detached',
+] as const;
+
+/**
+ * Captures and stores CDP events for diagnostic analysis.
+ *
+ * Usage:
+ * 1. Create logger and attach to CDP client before navigation
+ * 2. Perform navigation/action
+ * 3. If snapshot fails, retrieve events for analysis
+ * 4. Clear events before next operation
+ */
+export class CdpEventLogger {
+  private events: CdpEventEntry[] = [];
+  private cdp: CdpClient | null = null;
+  private handlers = new Map<string, (params: unknown) => void>();
+  private maxEvents = 100; // Prevent memory issues
+
+  /**
+   * Attach to CDP client and start capturing events.
+   */
+  attach(cdp: CdpClient): void {
+    this.cdp = cdp;
+
+    for (const eventName of DIAGNOSTIC_EVENTS) {
+      const handler = (params: unknown) => {
+        this.captureEvent(eventName, params);
+      };
+      this.handlers.set(eventName, handler);
+      cdp.on(eventName, handler);
+    }
+  }
+
+  /**
+   * Detach from CDP client and stop capturing.
+   */
+  detach(): void {
+    if (!this.cdp) return;
+
+    for (const [eventName, handler] of this.handlers) {
+      this.cdp.off(eventName, handler);
+    }
+    this.handlers.clear();
+    this.cdp = null;
+  }
+
+  /**
+   * Get all captured events.
+   */
+  getEvents(): CdpEventEntry[] {
+    return [...this.events];
+  }
+
+  /**
+   * Clear captured events.
+   */
+  clear(): void {
+    this.events = [];
+  }
+
+  /**
+   * Get events as formatted diagnostic string.
+   */
+  formatForDiagnostics(): string {
+    if (this.events.length === 0) {
+      return 'No CDP events captured';
+    }
+
+    return this.events
+      .map((e) => `[${e.localTimestamp}] ${e.event}: ${JSON.stringify(e.params)}`)
+      .join('\n');
+  }
+
+  private captureEvent(event: string, params: unknown): void {
+    // Trim old events if at capacity
+    if (this.events.length >= this.maxEvents) {
+      this.events.shift();
+    }
+
+    this.events.push({
+      event,
+      params,
+      localTimestamp: Date.now(),
+    });
+  }
+}

--- a/src/diagnostics/index.ts
+++ b/src/diagnostics/index.ts
@@ -5,8 +5,4 @@
  */
 
 export { CdpEventLogger, type CdpEventEntry } from './cdp-event-logger.js';
-export {
-  checkPageHealth,
-  formatHealthReport,
-  type PageHealthReport,
-} from './page-health.js';
+export { checkPageHealth, formatHealthReport, type PageHealthReport } from './page-health.js';

--- a/src/diagnostics/index.ts
+++ b/src/diagnostics/index.ts
@@ -1,0 +1,12 @@
+/**
+ * Diagnostics Module
+ *
+ * Tools for debugging snapshot failures and page state issues.
+ */
+
+export { CdpEventLogger, type CdpEventEntry } from './cdp-event-logger.js';
+export {
+  checkPageHealth,
+  formatHealthReport,
+  type PageHealthReport,
+} from './page-health.js';

--- a/src/diagnostics/page-health.ts
+++ b/src/diagnostics/page-health.ts
@@ -1,0 +1,129 @@
+/**
+ * Page Health Diagnostics
+ *
+ * Collects page state to help diagnose snapshot failures.
+ * Checks title, content accessibility, frame state, and more.
+ */
+
+import type { Page } from 'puppeteer-core';
+
+/** Health check report for a page */
+export interface PageHealthReport {
+  /** Overall health - false if any critical errors */
+  isHealthy: boolean;
+  /** Page URL */
+  url: string;
+  /** Page title (empty title is a warning sign) */
+  title: string;
+  /** Length of raw HTML content (0 = problem) */
+  contentLength: number;
+  /** Error message if content() failed */
+  contentError?: string;
+  /** Main frame URL */
+  mainFrameUrl?: string;
+  /** Is the page closed? */
+  isClosed: boolean;
+  /** Warning indicators */
+  warnings: string[];
+  /** Error indicators (critical) */
+  errors: string[];
+  /** Timestamp of check */
+  timestamp: number;
+}
+
+/**
+ * Perform health check on a page.
+ *
+ * This is a diagnostic tool to understand why snapshots might fail.
+ * Call this when snapshot returns empty to gather evidence.
+ */
+export async function checkPageHealth(page: Page): Promise<PageHealthReport> {
+  const timestamp = Date.now();
+  const warnings: string[] = [];
+  const errors: string[] = [];
+
+  // Check if page is closed
+  const isClosed = page.isClosed();
+  if (isClosed) {
+    errors.push('page_closed');
+  }
+
+  // Get URL and title
+  let url = '';
+  let title = '';
+  try {
+    url = page.url();
+    title = await page.title();
+  } catch {
+    // Page may be in bad state
+  }
+
+  if (!title) {
+    warnings.push('empty_title');
+  }
+
+  // Try to get content length
+  let contentLength = 0;
+  let contentError: string | undefined;
+  if (!isClosed) {
+    try {
+      const content = await page.content();
+      contentLength = content.length;
+      if (contentLength === 0) {
+        errors.push('empty_content');
+      }
+    } catch (err) {
+      errors.push('content_error');
+      contentError = err instanceof Error ? err.message : String(err);
+    }
+  }
+
+  // Get main frame info
+  let mainFrameUrl: string | undefined;
+  try {
+    const mainFrame = page.mainFrame();
+    mainFrameUrl = mainFrame.url();
+  } catch {
+    // Frame may be detached
+  }
+
+  return {
+    isHealthy: errors.length === 0,
+    url,
+    title,
+    contentLength,
+    contentError,
+    mainFrameUrl,
+    isClosed,
+    warnings,
+    errors,
+    timestamp,
+  };
+}
+
+/**
+ * Format health report for logging/display.
+ */
+export function formatHealthReport(report: PageHealthReport): string {
+  const lines: string[] = [];
+
+  lines.push(`Page Health: ${report.isHealthy ? 'HEALTHY' : 'UNHEALTHY'}`);
+  lines.push(`  URL: ${report.url}`);
+  lines.push(`  Title: ${report.title || '(empty)'}`);
+  lines.push(`  Content Length: ${report.contentLength}`);
+  lines.push(`  Page Closed: ${report.isClosed}`);
+
+  if (report.warnings.length > 0) {
+    lines.push(`  Warnings: ${report.warnings.join(', ')}`);
+  }
+
+  if (report.errors.length > 0) {
+    lines.push(`  Errors: ${report.errors.join(', ')}`);
+  }
+
+  if (report.contentError) {
+    lines.push(`  Content Error: ${report.contentError}`);
+  }
+
+  return lines.join('\n');
+}

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -7,6 +7,7 @@
 
 import type { BaseSnapshot, ReadableNode } from '../snapshot/snapshot.types.js';
 import type { ObservationGroups } from '../observation/observation.types.js';
+import type { PageHealthReport } from '../diagnostics/page-health.js';
 
 // ============================================================================
 // State Handle Types
@@ -54,6 +55,21 @@ export interface StateResponseObject {
    * Optional, only present if observations were captured.
    */
   observations?: ObservationGroups;
+
+  /**
+   * Diagnostics for debugging snapshot failures.
+   * Only present when snapshot is unhealthy and diagnostics were collected.
+   */
+  diagnostics?: SnapshotDiagnostics;
+}
+
+/**
+ * Diagnostics collected when snapshot capture fails.
+ * Helps debug why a page couldn't be captured.
+ */
+export interface SnapshotDiagnostics {
+  /** Page health report with URL, title, content status */
+  pageHealth: PageHealthReport;
 }
 
 /**

--- a/tests/integration/snapshot-diagnostics.test.ts
+++ b/tests/integration/snapshot-diagnostics.test.ts
@@ -1,0 +1,262 @@
+/**
+ * Integration test for Snapshot Diagnostics Flow
+ *
+ * Verifies the full diagnostic flow works end-to-end - from snapshot capture
+ * failure to diagnostics appearing in the output.
+ *
+ * This is not a "real browser" integration test; it uses mocks to test the
+ * integration between snapshot-health, snapshot-compiler, and page-health modules.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { captureWithStabilization } from '../../src/snapshot/snapshot-health.js';
+import { MockCdpClient } from '../mocks/cdp-client.mock.js';
+import { createMockPage, type MockPage } from '../mocks/puppeteer.mock.js';
+import type { Page } from 'puppeteer-core';
+import type { CdpClient } from '../../src/cdp/cdp-client.interface.js';
+
+// Mock compileSnapshot to return empty snapshot for failure scenarios
+vi.mock('../../src/snapshot/index.js', () => ({
+  compileSnapshot: vi.fn().mockResolvedValue({
+    snapshot_id: 'snap-test',
+    page_id: 'page-test',
+    url: 'https://example.com',
+    title: '',
+    nodes: [],
+    meta: {
+      node_count: 0,
+      interactive_count: 0,
+      capture_duration_ms: 100,
+    },
+    frames: [],
+    document: { documentURL: 'https://example.com' },
+  }),
+}));
+
+// Mock DOM stabilizer
+vi.mock('../../src/delta/dom-stabilizer.js', () => ({
+  stabilizeDom: vi.fn().mockResolvedValue({ status: 'stable', waitTimeMs: 50 }),
+}));
+
+// We do NOT mock page-health - let it run against the mock page
+// This tests the real integration between checkPageHealth and the mock page
+
+import { compileSnapshot } from '../../src/snapshot/index.js';
+
+describe('Snapshot Diagnostics Integration', () => {
+  let mockCdp: CdpClient;
+  let mockPageObj: MockPage;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCdp = new MockCdpClient() as unknown as CdpClient;
+  });
+
+  it('should provide actionable diagnostics for empty snapshot with empty content', async () => {
+    // Create page with empty title and content - both diagnostic indicators
+    mockPageObj = createMockPage({
+      url: 'https://example.com',
+      title: '', // Empty title - warning indicator
+      content: '', // Empty content - error indicator
+    });
+
+    const result = await captureWithStabilization(
+      mockCdp,
+      mockPageObj as unknown as Page,
+      'page-test',
+      {
+        maxRetries: 1,
+        retryDelayMs: 10,
+        includeDiagnostics: true,
+      }
+    );
+
+    // Verify we get useful diagnostics
+    expect(result.health.valid).toBe(false);
+    expect(result.health.reason).toBe('empty');
+    expect(result.diagnostics).toBeDefined();
+    expect(result.diagnostics?.pageHealth).toBeDefined();
+
+    // Verify specific diagnostic indicators
+    const pageHealth = result.diagnostics!.pageHealth;
+    expect(pageHealth.isHealthy).toBe(false);
+    expect(pageHealth.errors).toContain('empty_content');
+    expect(pageHealth.warnings).toContain('empty_title');
+  });
+
+  it('should include page URL and title in diagnostics', async () => {
+    mockPageObj = createMockPage({
+      url: 'https://test-site.example.com/path',
+      title: '',
+      content: '', // Empty content for diagnostics
+    });
+
+    const result = await captureWithStabilization(
+      mockCdp,
+      mockPageObj as unknown as Page,
+      'page-test',
+      {
+        maxRetries: 1,
+        includeDiagnostics: true,
+      }
+    );
+
+    expect(result.diagnostics).toBeDefined();
+    expect(result.diagnostics?.pageHealth.url).toBe('https://test-site.example.com/path');
+    expect(result.diagnostics?.pageHealth.title).toBe('');
+    expect(result.diagnostics?.pageHealth.contentLength).toBe(0);
+  });
+
+  it('should not include diagnostics when snapshot is healthy', async () => {
+    // Override the mock for this test to return a healthy snapshot
+    vi.mocked(compileSnapshot).mockResolvedValueOnce({
+      snapshot_id: 'snap-test',
+      page_id: 'page-test',
+      url: 'https://example.com',
+      title: 'Test Page',
+      nodes: [{ idx: 0, kind: 'button', label: 'Click me' }],
+      meta: {
+        node_count: 1,
+        interactive_count: 1,
+        capture_duration_ms: 100,
+      },
+      frames: [],
+      document: { documentURL: 'https://example.com' },
+    } as never);
+
+    mockPageObj = createMockPage({
+      url: 'https://example.com',
+      title: 'Test Page',
+    });
+
+    const result = await captureWithStabilization(
+      mockCdp,
+      mockPageObj as unknown as Page,
+      'page-test',
+      {
+        includeDiagnostics: true,
+      }
+    );
+
+    expect(result.health.valid).toBe(true);
+    expect(result.diagnostics).toBeUndefined();
+  });
+
+  it('should not include diagnostics when includeDiagnostics is false', async () => {
+    mockPageObj = createMockPage({
+      url: 'https://example.com',
+      title: '',
+      content: '', // Empty content
+    });
+
+    const result = await captureWithStabilization(
+      mockCdp,
+      mockPageObj as unknown as Page,
+      'page-test',
+      {
+        maxRetries: 1,
+        retryDelayMs: 10,
+        includeDiagnostics: false, // Explicitly disabled
+      }
+    );
+
+    expect(result.health.valid).toBe(false);
+    expect(result.diagnostics).toBeUndefined();
+  });
+
+  it('should report page closed error when page is closed', async () => {
+    mockPageObj = createMockPage({
+      url: 'https://example.com',
+      title: '',
+    });
+    // Set page as closed by modifying the mock's return value
+    mockPageObj.isClosed.mockReturnValue(true);
+
+    const result = await captureWithStabilization(
+      mockCdp,
+      mockPageObj as unknown as Page,
+      'page-test',
+      {
+        maxRetries: 1,
+        includeDiagnostics: true,
+      }
+    );
+
+    expect(result.diagnostics).toBeDefined();
+    expect(result.diagnostics?.pageHealth.isClosed).toBe(true);
+    expect(result.diagnostics?.pageHealth.errors).toContain('page_closed');
+  });
+
+  it('should correctly track attempt count in diagnostics scenario', async () => {
+    mockPageObj = createMockPage({
+      url: 'https://example.com',
+      title: '',
+      content: '', // Empty content
+    });
+
+    const result = await captureWithStabilization(
+      mockCdp,
+      mockPageObj as unknown as Page,
+      'page-test',
+      {
+        maxRetries: 3,
+        retryDelayMs: 10,
+        includeDiagnostics: true,
+      }
+    );
+
+    // Should have attempted all retries before collecting diagnostics
+    expect(result.attempts).toBe(3);
+    expect(result.health.valid).toBe(false);
+    expect(result.diagnostics).toBeDefined();
+  });
+
+  it('should handle content fetch error gracefully', async () => {
+    mockPageObj = createMockPage({
+      url: 'https://example.com',
+      title: 'Some Title',
+    });
+    // Simulate content() throwing an error
+    mockPageObj.content.mockRejectedValue(new Error('Page context destroyed'));
+
+    const result = await captureWithStabilization(
+      mockCdp,
+      mockPageObj as unknown as Page,
+      'page-test',
+      {
+        maxRetries: 1,
+        includeDiagnostics: true,
+      }
+    );
+
+    expect(result.diagnostics).toBeDefined();
+    expect(result.diagnostics?.pageHealth.errors).toContain('content_error');
+    expect(result.diagnostics?.pageHealth.contentError).toContain('Page context destroyed');
+  });
+
+  it('should report healthy page indicators even when snapshot fails', async () => {
+    // Page has content but snapshot extraction failed for other reasons
+    mockPageObj = createMockPage({
+      url: 'https://example.com',
+      title: 'Test Page With Content',
+      content: '<html><body><button>Click me</button></body></html>',
+    });
+
+    const result = await captureWithStabilization(
+      mockCdp,
+      mockPageObj as unknown as Page,
+      'page-test',
+      {
+        maxRetries: 1,
+        includeDiagnostics: true,
+      }
+    );
+
+    // Page is healthy but snapshot failed (could be AX/CDP issue)
+    expect(result.diagnostics).toBeDefined();
+    expect(result.diagnostics?.pageHealth.isHealthy).toBe(true);
+    expect(result.diagnostics?.pageHealth.errors).toHaveLength(0);
+    expect(result.diagnostics?.pageHealth.contentLength).toBeGreaterThan(0);
+    expect(result.diagnostics?.pageHealth.title).toBe('Test Page With Content');
+  });
+});

--- a/tests/mocks/puppeteer.mock.ts
+++ b/tests/mocks/puppeteer.mock.ts
@@ -139,7 +139,9 @@ export function createMockPage(
     viewport: vi.fn().mockReturnValue(options.viewport ?? { width: 1280, height: 720 }),
     createCDPSession: vi.fn().mockResolvedValue(cdpSession),
     cookies: vi.fn().mockResolvedValue([]),
-    content: vi.fn().mockResolvedValue(options.content ?? '<html><head></head><body></body></html>'),
+    content: vi
+      .fn()
+      .mockResolvedValue(options.content ?? '<html><head></head><body></body></html>'),
     mainFrame: vi.fn().mockReturnValue(mainFrame),
     on: vi.fn(),
     off: vi.fn(),
@@ -199,7 +201,9 @@ export function createMockPageWithEvents(
     viewport: vi.fn().mockReturnValue(options.viewport ?? { width: 1280, height: 720 }),
     createCDPSession: vi.fn().mockResolvedValue(cdpSession),
     cookies: vi.fn().mockResolvedValue([]),
-    content: vi.fn().mockResolvedValue(options.content ?? '<html><head></head><body></body></html>'),
+    content: vi
+      .fn()
+      .mockResolvedValue(options.content ?? '<html><head></head><body></body></html>'),
     mainFrame: vi.fn().mockReturnValue(mainFrame),
     on: vi.fn((event: string, handler: (arg: unknown) => void) => {
       getOrCreateListenerSet(event).add(handler);

--- a/tests/mocks/puppeteer.mock.ts
+++ b/tests/mocks/puppeteer.mock.ts
@@ -38,6 +38,14 @@ export interface MockCDPSession {
 }
 
 /**
+ * Mock Frame - Puppeteer-specific API
+ */
+export interface MockFrame {
+  url: Mock;
+  name: Mock;
+}
+
+/**
  * Mock Page - Puppeteer-specific API
  */
 export interface MockPage {
@@ -50,6 +58,8 @@ export interface MockPage {
   viewport: Mock; // Puppeteer uses viewport() instead of viewportSize()
   createCDPSession: Mock; // Puppeteer creates CDP session from Page
   cookies: Mock;
+  content: Mock; // Get page HTML content
+  mainFrame: Mock; // Get main frame
   on: Mock;
   off: Mock;
 }
@@ -89,6 +99,21 @@ export function createMockCDPSession(): MockCDPSession {
 }
 
 /**
+ * Creates a mock Frame
+ */
+export function createMockFrame(
+  options: {
+    url?: string;
+    name?: string;
+  } = {}
+): MockFrame {
+  return {
+    url: vi.fn().mockReturnValue(options.url ?? 'about:blank'),
+    name: vi.fn().mockReturnValue(options.name ?? ''),
+  };
+}
+
+/**
  * Creates a mock Page
  */
 export function createMockPage(
@@ -97,9 +122,12 @@ export function createMockPage(
     title?: string;
     viewport?: { width: number; height: number };
     cdpSession?: MockCDPSession;
+    content?: string;
+    mainFrame?: MockFrame;
   } = {}
 ): MockPage {
   const cdpSession = options.cdpSession ?? createMockCDPSession();
+  const mainFrame = options.mainFrame ?? createMockFrame({ url: options.url });
 
   return {
     url: vi.fn().mockReturnValue(options.url ?? 'about:blank'),
@@ -111,6 +139,8 @@ export function createMockPage(
     viewport: vi.fn().mockReturnValue(options.viewport ?? { width: 1280, height: 720 }),
     createCDPSession: vi.fn().mockResolvedValue(cdpSession),
     cookies: vi.fn().mockResolvedValue([]),
+    content: vi.fn().mockResolvedValue(options.content ?? '<html><head></head><body></body></html>'),
+    mainFrame: vi.fn().mockReturnValue(mainFrame),
     on: vi.fn(),
     off: vi.fn(),
   };
@@ -144,10 +174,13 @@ export function createMockPageWithEvents(
     title?: string;
     viewport?: { width: number; height: number };
     cdpSession?: MockCDPSession;
+    content?: string;
+    mainFrame?: MockFrame;
   } = {}
 ): MockPageWithEvents {
   const listeners = new Map<string, Set<(arg: unknown) => void>>();
   const cdpSession = options.cdpSession ?? createMockCDPSession();
+  const mainFrame = options.mainFrame ?? createMockFrame({ url: options.url });
 
   const getOrCreateListenerSet = (event: string): Set<(arg: unknown) => void> => {
     if (!listeners.has(event)) {
@@ -166,6 +199,8 @@ export function createMockPageWithEvents(
     viewport: vi.fn().mockReturnValue(options.viewport ?? { width: 1280, height: 720 }),
     createCDPSession: vi.fn().mockResolvedValue(cdpSession),
     cookies: vi.fn().mockResolvedValue([]),
+    content: vi.fn().mockResolvedValue(options.content ?? '<html><head></head><body></body></html>'),
+    mainFrame: vi.fn().mockReturnValue(mainFrame),
     on: vi.fn((event: string, handler: (arg: unknown) => void) => {
       getOrCreateListenerSet(event).add(handler);
     }),

--- a/tests/unit/diagnostics/cdp-event-logger.test.ts
+++ b/tests/unit/diagnostics/cdp-event-logger.test.ts
@@ -17,18 +17,9 @@ describe('CdpEventLogger', () => {
     it('should subscribe to Page domain events', () => {
       logger.attach(mockCdp);
 
-      expect(mockCdp.onSpy).toHaveBeenCalledWith(
-        'Page.frameNavigated',
-        expect.any(Function)
-      );
-      expect(mockCdp.onSpy).toHaveBeenCalledWith(
-        'Page.loadEventFired',
-        expect.any(Function)
-      );
-      expect(mockCdp.onSpy).toHaveBeenCalledWith(
-        'Page.domContentEventFired',
-        expect.any(Function)
-      );
+      expect(mockCdp.onSpy).toHaveBeenCalledWith('Page.frameNavigated', expect.any(Function));
+      expect(mockCdp.onSpy).toHaveBeenCalledWith('Page.loadEventFired', expect.any(Function));
+      expect(mockCdp.onSpy).toHaveBeenCalledWith('Page.domContentEventFired', expect.any(Function));
     });
 
     it('should subscribe to Runtime domain events', () => {
@@ -84,14 +75,8 @@ describe('CdpEventLogger', () => {
       logger.attach(mockCdp);
       logger.detach();
 
-      expect(mockCdp.offSpy).toHaveBeenCalledWith(
-        'Page.frameNavigated',
-        expect.any(Function)
-      );
-      expect(mockCdp.offSpy).toHaveBeenCalledWith(
-        'Page.loadEventFired',
-        expect.any(Function)
-      );
+      expect(mockCdp.offSpy).toHaveBeenCalledWith('Page.frameNavigated', expect.any(Function));
+      expect(mockCdp.offSpy).toHaveBeenCalledWith('Page.loadEventFired', expect.any(Function));
     });
 
     it('should handle detach when not attached', () => {

--- a/tests/unit/diagnostics/cdp-event-logger.test.ts
+++ b/tests/unit/diagnostics/cdp-event-logger.test.ts
@@ -1,0 +1,135 @@
+// tests/unit/diagnostics/cdp-event-logger.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { CdpEventLogger } from '../../../src/diagnostics/cdp-event-logger.js';
+import { MockCdpClient } from '../../mocks/cdp-client.mock.js';
+
+describe('CdpEventLogger', () => {
+  let logger: CdpEventLogger;
+  let mockCdp: MockCdpClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCdp = new MockCdpClient();
+    logger = new CdpEventLogger();
+  });
+
+  describe('attach()', () => {
+    it('should subscribe to Page domain events', () => {
+      logger.attach(mockCdp);
+
+      expect(mockCdp.onSpy).toHaveBeenCalledWith(
+        'Page.frameNavigated',
+        expect.any(Function)
+      );
+      expect(mockCdp.onSpy).toHaveBeenCalledWith(
+        'Page.loadEventFired',
+        expect.any(Function)
+      );
+      expect(mockCdp.onSpy).toHaveBeenCalledWith(
+        'Page.domContentEventFired',
+        expect.any(Function)
+      );
+    });
+
+    it('should subscribe to Runtime domain events', () => {
+      logger.attach(mockCdp);
+
+      expect(mockCdp.onSpy).toHaveBeenCalledWith(
+        'Runtime.executionContextCreated',
+        expect.any(Function)
+      );
+      expect(mockCdp.onSpy).toHaveBeenCalledWith(
+        'Runtime.executionContextDestroyed',
+        expect.any(Function)
+      );
+    });
+  });
+
+  describe('getEvents()', () => {
+    it('should return empty array before any events', () => {
+      expect(logger.getEvents()).toEqual([]);
+    });
+
+    it('should capture and timestamp events', () => {
+      logger.attach(mockCdp);
+
+      // Use the MockCdpClient's emitEvent helper to trigger the event
+      mockCdp.emitEvent('Page.loadEventFired', { timestamp: 12345.67 });
+
+      const events = logger.getEvents();
+      expect(events).toHaveLength(1);
+      expect(events[0].event).toBe('Page.loadEventFired');
+      expect(events[0].params).toEqual({ timestamp: 12345.67 });
+      expect(events[0].localTimestamp).toBeGreaterThan(0);
+    });
+  });
+
+  describe('clear()', () => {
+    it('should remove all captured events', () => {
+      logger.attach(mockCdp);
+
+      // Emit an event
+      mockCdp.emitEvent('Page.loadEventFired', {});
+
+      expect(logger.getEvents()).toHaveLength(1);
+
+      logger.clear();
+
+      expect(logger.getEvents()).toHaveLength(0);
+    });
+  });
+
+  describe('detach()', () => {
+    it('should unsubscribe from all events', () => {
+      logger.attach(mockCdp);
+      logger.detach();
+
+      expect(mockCdp.offSpy).toHaveBeenCalledWith(
+        'Page.frameNavigated',
+        expect.any(Function)
+      );
+      expect(mockCdp.offSpy).toHaveBeenCalledWith(
+        'Page.loadEventFired',
+        expect.any(Function)
+      );
+    });
+
+    it('should handle detach when not attached', () => {
+      // Should not throw when detaching without prior attach
+      expect(() => logger.detach()).not.toThrow();
+    });
+  });
+
+  describe('formatForDiagnostics()', () => {
+    it('should return message when no events captured', () => {
+      expect(logger.formatForDiagnostics()).toBe('No CDP events captured');
+    });
+
+    it('should format events as diagnostic string', () => {
+      logger.attach(mockCdp);
+
+      mockCdp.emitEvent('Page.loadEventFired', { timestamp: 12345.67 });
+
+      const formatted = logger.formatForDiagnostics();
+      expect(formatted).toContain('Page.loadEventFired');
+      expect(formatted).toContain('12345.67');
+    });
+  });
+
+  describe('maxEvents limit', () => {
+    it('should trim old events when exceeding capacity', () => {
+      logger.attach(mockCdp);
+
+      // Emit 101 events (default max is 100)
+      for (let i = 0; i < 101; i++) {
+        mockCdp.emitEvent('Page.loadEventFired', { index: i });
+      }
+
+      const events = logger.getEvents();
+      expect(events).toHaveLength(100);
+      // First event should be trimmed, so index starts at 1
+      expect(events[0].params).toEqual({ index: 1 });
+      expect(events[99].params).toEqual({ index: 100 });
+    });
+  });
+});

--- a/tests/unit/diagnostics/page-health.test.ts
+++ b/tests/unit/diagnostics/page-health.test.ts
@@ -1,0 +1,153 @@
+// tests/unit/diagnostics/page-health.test.ts
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { checkPageHealth, PageHealthReport } from '../../../src/diagnostics/page-health.js';
+import type { Page } from 'puppeteer-core';
+import { createMockPage, MockPage } from '../../mocks/puppeteer.mock.js';
+
+describe('checkPageHealth', () => {
+  let mockPage: MockPage;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockPage = createMockPage({
+      url: 'https://example.com',
+      title: 'Example',
+    });
+  });
+
+  it('should return healthy status for a normal page', async () => {
+    // Mock content() to return HTML
+    mockPage.content.mockResolvedValue('<html><body>Hello</body></html>');
+
+    const report = await checkPageHealth(mockPage as unknown as Page);
+
+    expect(report.isHealthy).toBe(true);
+    expect(report.url).toBe('https://example.com');
+    expect(report.title).toBe('Example');
+    expect(report.contentLength).toBeGreaterThan(0);
+  });
+
+  it('should detect empty title as warning', async () => {
+    mockPage = createMockPage({
+      url: 'https://example.com',
+      title: '',
+    });
+    mockPage.content.mockResolvedValue('<html><body></body></html>');
+
+    const report = await checkPageHealth(mockPage as unknown as Page);
+
+    expect(report.warnings).toContain('empty_title');
+  });
+
+  it('should detect empty content', async () => {
+    mockPage.content.mockResolvedValue('');
+
+    const report = await checkPageHealth(mockPage as unknown as Page);
+
+    expect(report.isHealthy).toBe(false);
+    expect(report.errors).toContain('empty_content');
+  });
+
+  it('should detect closed page', async () => {
+    mockPage.isClosed.mockReturnValue(true);
+
+    const report = await checkPageHealth(mockPage as unknown as Page);
+
+    expect(report.isHealthy).toBe(false);
+    expect(report.errors).toContain('page_closed');
+  });
+
+  it('should handle content() throwing error', async () => {
+    mockPage.content.mockRejectedValue(new Error('Execution context was destroyed'));
+
+    const report = await checkPageHealth(mockPage as unknown as Page);
+
+    expect(report.isHealthy).toBe(false);
+    expect(report.errors).toContain('content_error');
+    expect(report.contentError).toContain('Execution context was destroyed');
+  });
+
+  it('should include main frame info', async () => {
+    mockPage.content.mockResolvedValue('<html></html>');
+    // The mainFrame is already set up by createMockPage with the page URL
+
+    const report = await checkPageHealth(mockPage as unknown as Page);
+
+    expect(report.mainFrameUrl).toBe('https://example.com');
+  });
+
+  it('should handle page.title() throwing error gracefully', async () => {
+    vi.mocked(mockPage.title).mockRejectedValue(new Error('Page crashed'));
+    mockPage.content.mockResolvedValue('<html></html>');
+
+    const report = await checkPageHealth(mockPage as unknown as Page);
+
+    // Should still return a report, just with empty title
+    expect(report.url).toBe('https://example.com');
+    expect(report.title).toBe('');
+    expect(report.warnings).toContain('empty_title');
+  });
+
+  it('should handle mainFrame() throwing error gracefully', async () => {
+    mockPage.content.mockResolvedValue('<html></html>');
+    vi.mocked(mockPage.mainFrame).mockImplementation(() => {
+      throw new Error('Frame detached');
+    });
+
+    const report = await checkPageHealth(mockPage as unknown as Page);
+
+    // Should still return a report, just without mainFrameUrl
+    expect(report.mainFrameUrl).toBeUndefined();
+    expect(report.isHealthy).toBe(true);
+  });
+});
+
+describe('formatHealthReport', () => {
+  it('should format healthy report', async () => {
+    const { formatHealthReport } = await import('../../../src/diagnostics/page-health.js');
+
+    const report: PageHealthReport = {
+      isHealthy: true,
+      url: 'https://example.com',
+      title: 'Example Page',
+      contentLength: 1234,
+      mainFrameUrl: 'https://example.com',
+      isClosed: false,
+      warnings: [],
+      errors: [],
+      timestamp: Date.now(),
+    };
+
+    const formatted = formatHealthReport(report);
+
+    expect(formatted).toContain('HEALTHY');
+    expect(formatted).toContain('https://example.com');
+    expect(formatted).toContain('Example Page');
+    expect(formatted).toContain('1234');
+  });
+
+  it('should format unhealthy report with errors', async () => {
+    const { formatHealthReport } = await import('../../../src/diagnostics/page-health.js');
+
+    const report: PageHealthReport = {
+      isHealthy: false,
+      url: 'https://example.com',
+      title: '',
+      contentLength: 0,
+      contentError: 'Execution context destroyed',
+      isClosed: false,
+      warnings: ['empty_title'],
+      errors: ['empty_content', 'content_error'],
+      timestamp: Date.now(),
+    };
+
+    const formatted = formatHealthReport(report);
+
+    expect(formatted).toContain('UNHEALTHY');
+    expect(formatted).toContain('(empty)');
+    expect(formatted).toContain('empty_title');
+    expect(formatted).toContain('empty_content');
+    expect(formatted).toContain('content_error');
+    expect(formatted).toContain('Execution context destroyed');
+  });
+});


### PR DESCRIPTION
## Summary

- Add new `src/diagnostics/` module for debugging snapshot failures
- **CdpEventLogger**: Captures CDP events (navigation lifecycle, execution contexts, errors) for post-mortem analysis
- **checkPageHealth()**: Collects page state (title, content length, frame status) to diagnose empty snapshots
- Integrate diagnostics into `capture_snapshot` - when snapshot returns empty, page health info is automatically included
- Fix network tracker timing bug: attach before navigation starts to avoid missing events

## Changes

- `src/diagnostics/cdp-event-logger.ts` - CDP event capture for debugging
- `src/diagnostics/page-health.ts` - Page state diagnostics
- `src/diagnostics/index.ts` - Module exports
- `src/snapshot/snapshot-compiler.ts` - Integrate diagnostics into capture
- `src/browser/session-manager.ts` - Fix network tracker attachment timing
- `src/tools/browser-tools.ts` - Include page health in empty snapshot responses
- Updated CLAUDE.md with diagnostics documentation

## Test plan

- [x] Unit tests for CdpEventLogger
- [x] Unit tests for checkPageHealth
- [x] Integration test for snapshot diagnostics flow
- [x] All existing tests pass (1493 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)