### PR TITLE
refactor: rename list_tabs to list_pages for API consistency

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ import {
   initializeTools,
   initializeFormTools,
   // Tool handlers
-  listTabs,
+  listPages,
   closePage,
   closeSession,
   navigate,
@@ -41,7 +41,7 @@ import {
   getFormUnderstanding,
   getFieldContext,
   // Input schemas only (all outputs are XML strings now)
-  ListTabsInputSchema,
+  ListPagesInputSchema,
   ClosePageInputSchema,
   CloseSessionInputSchema,
   NavigateInputSchema,
@@ -125,14 +125,14 @@ function initializeServer(): BrowserAutomationServer {
   // ============================================================================
 
   server.registerTool(
-    'list_tabs',
+    'list_pages',
     {
-      title: 'List Tabs',
+      title: 'List Pages',
       description:
-        'List all open browser tabs with their page_id, URL, and title. Use page_id to target a specific tab in other tools.',
-      inputSchema: ListTabsInputSchema.shape,
+        'List all open browser pages with their page_id, URL, and title. Use page_id to target a specific page in other tools.',
+      inputSchema: ListPagesInputSchema.shape,
     },
-    withLazyInit(listTabs, 'list_tabs')
+    withLazyInit(listPages, 'list_pages')
   );
 
   server.registerTool(

--- a/src/tools/browser-tools.ts
+++ b/src/tools/browser-tools.ts
@@ -62,7 +62,7 @@ import type { RuntimeHealth } from '../state/health.types.js';
 import {
   buildClosePageResponse,
   buildCloseSessionResponse,
-  buildListTabsResponse,
+  buildListPagesResponse,
   buildFindElementsResponse,
   buildGetNodeDetailsResponse,
   type FindElementsMatch,
@@ -378,19 +378,19 @@ async function executeNavigationAction(
 // ============================================================================
 
 /**
- * List all open browser tabs with their metadata.
+ * List all open browser pages with their metadata.
  *
- * @returns XML result with tab list
+ * @returns XML result with page list
  */
-export function listTabs(): import('./tool-schemas.js').ListTabsOutput {
+export function listPages(): import('./tool-schemas.js').ListPagesOutput {
   const session = getSessionManager();
   const pages = session.listPages();
-  const tabs = pages.map((h) => ({
+  const pageInfos = pages.map((h) => ({
     page_id: h.page_id,
     url: h.url ?? '',
     title: h.title ?? '',
   }));
-  return buildListTabsResponse(tabs);
+  return buildListPagesResponse(pageInfos);
 }
 
 /**

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -8,7 +8,7 @@ export { initializeTools, getSnapshotStore } from './browser-tools.js';
 
 // Tool handlers - Simplified API
 export {
-  listTabs,
+  listPages,
   closePage,
   closeSession,
   navigate,
@@ -32,11 +32,11 @@ export { ensureBrowserForTools, getSessionManager } from '../server/server-confi
 
 // Schemas - Simplified API
 export {
-  // list_tabs
-  ListTabsInputSchema,
-  ListTabsOutputSchema,
-  type ListTabsInput,
-  type ListTabsOutput,
+  // list_pages
+  ListPagesInputSchema,
+  ListPagesOutputSchema,
+  type ListPagesInput,
+  type ListPagesOutput,
   // close_page
   ClosePageInputSchema,
   ClosePageOutputSchema,

--- a/src/tools/response-builder.ts
+++ b/src/tools/response-builder.ts
@@ -80,30 +80,30 @@ export function buildErrorResponse(pageId: string, error: Error | string): State
 // ============================================================================
 
 /**
- * Tab metadata for list_tabs response.
+ * Page metadata for list_pages response.
  */
-export interface TabInfo {
+export interface PageInfo {
   page_id: string;
   url: string;
   title: string;
 }
 
 /**
- * Build XML response for list_tabs tool.
+ * Build XML response for list_pages tool.
  *
- * @param tabs - Array of tab metadata
+ * @param pages - Array of page metadata
  * @returns XML result string
  */
-export function buildListTabsResponse(tabs: TabInfo[]): string {
-  const tabLines = tabs.map(
-    (tab) =>
-      `    <tab page_id="${escapeXml(tab.page_id)}" url="${escapeXml(tab.url)}" title="${escapeXml(tab.title)}" />`
+export function buildListPagesResponse(pages: PageInfo[]): string {
+  const pageLines = pages.map(
+    (page) =>
+      `    <page page_id="${escapeXml(page.page_id)}" url="${escapeXml(page.url)}" title="${escapeXml(page.title)}" />`
   );
 
-  return `<result type="list_tabs" status="success">
-  <tabs count="${tabs.length}">
-${tabLines.join('\n')}
-  </tabs>
+  return `<result type="list_pages" status="success">
+  <pages count="${pages.length}">
+${pageLines.join('\n')}
+  </pages>
 </result>`;
 }
 

--- a/src/tools/tool-schemas.ts
+++ b/src/tools/tool-schemas.ts
@@ -405,16 +405,16 @@ export type ClickOutcome = z.infer<typeof ClickOutcomeSchema>;
 // ============================================================================
 
 // ============================================================================
-// list_tabs - List all open browser tabs
+// list_pages - List all open browser pages
 // ============================================================================
 
-export const ListTabsInputSchema = z.object({});
+export const ListPagesInputSchema = z.object({});
 
 /** Returns XML result string */
-export const ListTabsOutputSchema = z.string();
+export const ListPagesOutputSchema = z.string();
 
-export type ListTabsInput = z.infer<typeof ListTabsInputSchema>;
-export type ListTabsOutput = z.infer<typeof ListTabsOutputSchema>;
+export type ListPagesInput = z.infer<typeof ListPagesInputSchema>;
+export type ListPagesOutput = z.infer<typeof ListPagesOutputSchema>;
 
 // ============================================================================
 // close_page - Close a specific page

--- a/tests/unit/tools/list-pages.test.ts
+++ b/tests/unit/tools/list-pages.test.ts
@@ -1,7 +1,7 @@
 /**
- * list_tabs Tool Tests
+ * list_pages Tool Tests
  *
- * Verifies that listTabs returns correct XML for open tabs.
+ * Verifies that listPages returns correct XML for open pages.
  */
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { SessionManager } from '../../../src/browser/session-manager.js';
@@ -78,23 +78,23 @@ vi.mock('../../../src/query/query-engine.js', () => ({
   QueryEngine: vi.fn(),
 }));
 
-import { initializeTools, listTabs } from '../../../src/tools/browser-tools.js';
+import { initializeTools, listPages } from '../../../src/tools/browser-tools.js';
 
-describe('listTabs', () => {
+describe('listPages', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('should return empty tabs list when no pages are registered', () => {
+  it('should return empty pages list when no pages are registered', () => {
     mockListPages.mockReturnValue([]);
     initializeTools(mockSessionManager);
 
-    const result = listTabs();
+    const result = listPages();
 
-    expect(result).toContain('type="list_tabs"');
+    expect(result).toContain('type="list_pages"');
     expect(result).toContain('status="success"');
     expect(result).toContain('count="0"');
-    expect(result).not.toContain('<tab ');
+    expect(result).not.toContain('<page ');
   });
 
   it('should return correct metadata for multiple pages', () => {
@@ -118,7 +118,7 @@ describe('listTabs', () => {
     ]);
     initializeTools(mockSessionManager);
 
-    const result = listTabs();
+    const result = listPages();
 
     expect(result).toContain('count="2"');
     expect(result).toContain('page_id="page-abc"');
@@ -140,7 +140,7 @@ describe('listTabs', () => {
     ]);
     initializeTools(mockSessionManager);
 
-    const result = listTabs();
+    const result = listPages();
 
     expect(result).toContain('count="1"');
     expect(result).toContain('page_id="page-new"');
@@ -148,7 +148,7 @@ describe('listTabs', () => {
     expect(result).toContain('title=""');
   });
 
-  it('should escape XML special characters in tab metadata', () => {
+  it('should escape XML special characters in page metadata', () => {
     mockListPages.mockReturnValue([
       {
         page_id: 'page-special',
@@ -161,7 +161,7 @@ describe('listTabs', () => {
     ]);
     initializeTools(mockSessionManager);
 
-    const result = listTabs();
+    const result = listPages();
 
     expect(result).toContain('&amp;');
     expect(result).toContain('&lt;Page&gt;');


### PR DESCRIPTION
## Summary

Renames the `list_tabs` tool to `list_pages` to align with the rest of the API which uses `page_id` and `close_page` terminology.

Since the users are LLM/AI agents, consistent terminology throughout the API improves comprehension.

## Changes

- Tool: `list_tabs` → `list_pages`
- Function: `listTabs` → `listPages`
- Types: `ListTabs*` → `ListPages*`
- Response types: `TabInfo` → `PageInfo`
- XML output: `<tabs>` → `<pages>`, `<tab>` → `<page>`
- Test file renamed accordingly

## Test plan

- [x] All existing tests pass (1445 tests)
- [x] Renamed test file covers list_pages functionality

🤖 Generated with [Claude Code](https://claude.com/claude-code)