### PR TITLE
Refactor/improve tool descriptions

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -35,8 +35,10 @@ jobs:
       - name: Type check
         run: npm run type-check
 
-      - name: Install Chrome for Puppeteer
-        run: npx puppeteer browsers install chrome
+      - name: Install Chrome
+        uses: browser-actions/setup-chrome@v1
+        with:
+          chrome-version: stable
 
       - name: Run integration tests
         run: npm run test:integration

--- a/AGENT.md
+++ b/AGENT.md
@@ -6,12 +6,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Athena Browser MCP is an MCP (Model Context Protocol) server for AI-powered browser automation via Playwright and CDP (Chrome DevTools Protocol). It provides **semantic page snapshots** - compact, structured representations designed for LLM consumption with stable element IDs that survive DOM mutations.
 
-**18 Tools** across 5 categories:
+**19 Tools** across 6 categories:
 
-- **Session**: launch_browser, connect_browser, close_page, close_session
+- **Session**: list_tabs, close_page, close_session
 - **Navigation**: navigate, go_back, go_forward, reload
-- **Observation**: capture_snapshot, find_elements, get_node_details
+- **Observation**: capture_snapshot, find_elements, get_element_details
 - **Interaction**: click, type, press, select, hover, scroll_element_into_view, scroll_page
+- **Form Understanding**: get_form_understanding, get_field_context
 
 ## Build and Development Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Athena Browser MCP is an MCP (Model Context Protocol) server for AI-powered browser automation via Puppeteer and CDP (Chrome DevTools Protocol). It provides **semantic page snapshots** - compact, structured representations designed for LLM consumption with stable element IDs that survive DOM mutations.
 
-**18 Tools** across 6 categories:
+**19 Tools** across 6 categories:
 
-- **Session**: close_page, close_session
+- **Session**: list_tabs, close_page, close_session
 - **Navigation**: navigate, go_back, go_forward, reload
-- **Observation**: capture_snapshot, find_elements, get_node_details
+- **Observation**: capture_snapshot, find_elements, get_element_details
 - **Interaction**: click, type, press, select, hover, scroll_element_into_view, scroll_page
 - **Form Understanding**: get_form_understanding, get_field_context
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -223,7 +223,7 @@ function initializeServer(): BrowserAutomationServer {
     {
       title: 'Find Elements',
       description:
-        'Search for interactive elements OR read page text content. Filter by `kind` (button, link, textbox), `label` (fuzzy text match), or `region` (header, main, footer). To READ page content, ensure `include_readable: true` (default) which includes paragraphs and headings.',
+        'Search for interactive elements OR read page text content. Filter by `kind` (button, link, textbox), `label` (case-insensitive substring match), or `region` (header, main, footer). To READ page content, ensure `include_readable: true` (default) which includes paragraphs and headings.',
       inputSchema: FindElementsInputSchema.shape,
     },
     withLazyInit(findElements, 'find_elements')

--- a/src/index.ts
+++ b/src/index.ts
@@ -129,7 +129,7 @@ function initializeServer(): BrowserAutomationServer {
     {
       title: 'List Pages',
       description:
-        'List all open browser pages with their page_id, URL, and title. Use page_id to target a specific page in other tools.',
+        'List all open browser pages with their page_id, URL, and title. Use when working with multiple pages or to get the page_id for targeting a specific page.',
       inputSchema: ListPagesInputSchema.shape,
     },
     withLazyInit(listPages, 'list_pages')
@@ -139,7 +139,7 @@ function initializeServer(): BrowserAutomationServer {
     'close_page',
     {
       title: 'Close Page',
-      description: 'Close a specific page by page_id.',
+      description: 'Close a browser tab. Use list_pages first to get the page_id.',
       inputSchema: ClosePageInputSchema.shape,
     },
     withLazyInit(closePage, 'close_page')
@@ -150,7 +150,7 @@ function initializeServer(): BrowserAutomationServer {
     {
       title: 'Close Session',
       description:
-        'Close the browser session and clear all state. The browser will be re-initialized automatically on the next tool call.',
+        'Close the entire browser and clear all state. Use when done with browser tasks or to reset after errors. Browser auto-restarts on next tool call.',
       inputSchema: CloseSessionInputSchema.shape,
     },
     withLazyInit(closeSession, 'close_session')
@@ -164,7 +164,8 @@ function initializeServer(): BrowserAutomationServer {
     'navigate',
     {
       title: 'Navigate',
-      description: 'Navigate directly to a URL and return the new snapshot.',
+      description:
+        'Go to a URL. Returns page snapshot with interactive elements. This is typically your first action when starting browser automation.',
       inputSchema: NavigateInputSchema.shape,
     },
     withLazyInit(navigate, 'navigate')
@@ -174,7 +175,8 @@ function initializeServer(): BrowserAutomationServer {
     'go_back',
     {
       title: 'Go Back',
-      description: 'Navigate back in browser history.',
+      description:
+        'Go back one page in browser history (like clicking the back button). Returns updated page snapshot.',
       inputSchema: GoBackInputSchema.shape,
     },
     withLazyInit(goBack, 'go_back')
@@ -184,7 +186,7 @@ function initializeServer(): BrowserAutomationServer {
     'go_forward',
     {
       title: 'Go Forward',
-      description: 'Navigate forward in browser history.',
+      description: 'Go forward one page in browser history. Returns updated page snapshot.',
       inputSchema: GoForwardInputSchema.shape,
     },
     withLazyInit(goForward, 'go_forward')
@@ -194,7 +196,8 @@ function initializeServer(): BrowserAutomationServer {
     'reload',
     {
       title: 'Reload',
-      description: 'Reload the current page and return the refreshed snapshot.',
+      description:
+        'Refresh the current page. Use when content may be stale or after waiting for server-side changes. Returns updated snapshot.',
       inputSchema: ReloadInputSchema.shape,
     },
     withLazyInit(reload, 'reload')
@@ -204,7 +207,8 @@ function initializeServer(): BrowserAutomationServer {
     'capture_snapshot',
     {
       title: 'Capture Snapshot',
-      description: 'Capture a fresh snapshot of the current page.',
+      description:
+        'Re-capture the page state without performing any action. Use when the page may have changed on its own (timers, live updates, animations completing). NOT needed after click/type/etc - those already return fresh snapshots.',
       inputSchema: CaptureSnapshotInputSchema.shape,
     },
     withLazyInit(captureSnapshot, 'capture_snapshot')
@@ -218,20 +222,22 @@ function initializeServer(): BrowserAutomationServer {
     'find_elements',
     {
       title: 'Find Elements',
-      description: 'Find elements by kind, label, or region in the current snapshot.',
+      description:
+        'Search for interactive elements OR read page text content. Filter by `kind` (button, link, textbox), `label` (fuzzy text match), or `region` (header, main, footer). To READ page content, ensure `include_readable: true` (default) which includes paragraphs and headings.',
       inputSchema: FindElementsInputSchema.shape,
     },
     withLazyInit(findElements, 'find_elements')
   );
 
   server.registerTool(
-    'get_node_details',
+    'get_element_details',
     {
-      title: 'Get Node Details',
-      description: 'Return full details for a single eid.',
+      title: 'Get Element Details',
+      description:
+        'Get complete details for one element: exact position, size, state, attributes. Use when you need more info than find_elements provides, like precise coordinates or full attribute list.',
       inputSchema: GetNodeDetailsInputSchema.shape,
     },
-    withLazyInit(getNodeDetails, 'get_node_details')
+    withLazyInit(getNodeDetails, 'get_element_details')
   );
 
   // ============================================================================
@@ -242,7 +248,8 @@ function initializeServer(): BrowserAutomationServer {
     'scroll_element_into_view',
     {
       title: 'Scroll Element Into View',
-      description: 'Scroll a specific element into view.',
+      description:
+        'Scroll until a specific element is visible in the viewport. Use BEFORE clicking or interacting with elements that are off-screen.',
       inputSchema: ScrollElementIntoViewInputSchemaBase.shape,
     },
     withLazyInit(scrollElementIntoView, 'scroll_element_into_view')
@@ -252,7 +259,8 @@ function initializeServer(): BrowserAutomationServer {
     'scroll_page',
     {
       title: 'Scroll Page',
-      description: 'Scroll the page up or down by a specified amount.',
+      description:
+        'Scroll the viewport up or down by pixels. Use to explore page content, load lazy content, or reach elements below the fold. Returns updated snapshot.',
       inputSchema: ScrollPageInputSchema.shape,
     },
     withLazyInit(scrollPage, 'scroll_page')
@@ -262,7 +270,8 @@ function initializeServer(): BrowserAutomationServer {
     'click',
     {
       title: 'Click Element',
-      description: 'Click an element by eid.',
+      description:
+        'Click an element. Use for buttons, links, checkboxes, or any clickable element. Returns updated page snapshot reflecting any changes from the click.',
       inputSchema: ClickInputSchemaBase.shape,
     },
     withLazyInit(click, 'click')
@@ -272,7 +281,8 @@ function initializeServer(): BrowserAutomationServer {
     'type',
     {
       title: 'Type Text',
-      description: 'Type text into a specific element (by eid) with optional clearing.',
+      description:
+        'Type text into an input field, search box, or text area. Set `clear: true` to replace existing text instead of appending. Returns updated snapshot.',
       inputSchema: TypeInputSchemaBase.shape,
     },
     withLazyInit(type, 'type')
@@ -282,7 +292,8 @@ function initializeServer(): BrowserAutomationServer {
     'press',
     {
       title: 'Press Key',
-      description: 'Press a keyboard key with optional modifiers.',
+      description:
+        'Press a keyboard key (Enter, Tab, Escape, arrows, etc.) with optional Ctrl/Shift/Alt modifiers. Use for: submitting forms (Enter), moving between fields (Tab), closing dialogs (Escape), or keyboard shortcuts.',
       inputSchema: PressInputSchema.shape,
     },
     withLazyInit(press, 'press')
@@ -292,7 +303,8 @@ function initializeServer(): BrowserAutomationServer {
     'select',
     {
       title: 'Select Option',
-      description: 'Select an option from a <select> element (by eid) by value or text.',
+      description:
+        'Choose an option from a dropdown menu. Specify the option by its value attribute or visible text. Returns updated snapshot.',
       inputSchema: SelectInputSchemaBase.shape,
     },
     withLazyInit(select, 'select')
@@ -302,7 +314,8 @@ function initializeServer(): BrowserAutomationServer {
     'hover',
     {
       title: 'Hover Element',
-      description: 'Hover over an element by eid.',
+      description:
+        'Move mouse over an element without clicking. Use to trigger hover menus, tooltips, or reveal hidden content that appears on mouseover.',
       inputSchema: HoverInputSchemaBase.shape,
     },
     withLazyInit(hover, 'hover')
@@ -317,7 +330,7 @@ function initializeServer(): BrowserAutomationServer {
     {
       title: 'Get Form Understanding',
       description:
-        'Analyze forms on the page and return semantic understanding of form regions, fields, dependencies, and state. Use this to understand complex form interactions.',
+        'Analyze all forms on the page: fields, required inputs, validation rules, and field dependencies. Use BEFORE filling complex forms (multi-step, conditional fields) to understand what is required and in what order.',
       inputSchema: GetFormUnderstandingInputSchema.shape,
     },
     withLazyInit(getFormUnderstanding, 'get_form_understanding')
@@ -328,7 +341,7 @@ function initializeServer(): BrowserAutomationServer {
     {
       title: 'Get Field Context',
       description:
-        'Get detailed context for a specific form field including purpose inference, constraints, dependencies, and suggested next action.',
+        'Get detailed info about one form field: what it is for, valid input formats, dependencies on other fields, and suggested values. Use when unsure how to fill a specific field.',
       inputSchema: GetFieldContextInputSchema.shape,
     },
     withLazyInit(getFieldContext, 'get_field_context')

--- a/src/tools/browser-tools.ts
+++ b/src/tools/browser-tools.ts
@@ -64,7 +64,7 @@ import {
   buildCloseSessionResponse,
   buildListPagesResponse,
   buildFindElementsResponse,
-  buildGetNodeDetailsResponse,
+  buildGetElementDetailsResponse,
   type FindElementsMatch,
 } from './response-builder.js';
 import { ElementNotFoundError, StaleElementError, SnapshotRequiredError } from './errors.js';
@@ -698,7 +698,7 @@ export function getNodeDetails(
     details.attributes = { ...node.attributes };
   }
 
-  return buildGetNodeDetailsResponse(page_id, snap.snapshot_id, details);
+  return buildGetElementDetailsResponse(page_id, snap.snapshot_id, details);
 }
 
 /**

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -77,7 +77,7 @@ export {
   FindElementsOutputSchema,
   type FindElementsInput,
   type FindElementsOutput,
-  // get_node_details
+  // get_element_details
   GetNodeDetailsInputSchema,
   GetNodeDetailsOutputSchema,
   type GetNodeDetailsInput,

--- a/src/tools/response-builder.ts
+++ b/src/tools/response-builder.ts
@@ -208,14 +208,14 @@ export function buildFindElementsResponse(
 }
 
 /**
- * Build XML response for get_node_details tool.
+ * Build XML response for get_element_details tool.
  *
  * @param pageId - The page ID
  * @param snapshotId - The snapshot ID
  * @param node - The node details
  * @returns XML result string
  */
-export function buildGetNodeDetailsResponse(
+export function buildGetElementDetailsResponse(
   pageId: string,
   snapshotId: string,
   node: NodeDetails
@@ -223,7 +223,7 @@ export function buildGetNodeDetailsResponse(
   const lines: string[] = [];
 
   lines.push(
-    `<result type="get_node_details" page_id="${escapeXml(pageId)}" snapshot_id="${escapeXml(snapshotId)}">`
+    `<result type="get_element_details" page_id="${escapeXml(pageId)}" snapshot_id="${escapeXml(snapshotId)}">`
   );
 
   // Node element with core attributes

--- a/src/tools/tool-schemas.ts
+++ b/src/tools/tool-schemas.ts
@@ -674,9 +674,7 @@ const TypeInputSchemaBase = z.object({
   /** Stable element ID from find_elements or snapshot */
   eid: z
     .string()
-    .describe(
-      'Element ID of the input field from find_elements results or the page snapshot.'
-    ),
+    .describe('Element ID of the input field from find_elements results or the page snapshot.'),
   /** Clear existing text before typing (default: false) */
   clear: z
     .boolean()
@@ -715,7 +713,9 @@ export type PressOutput = z.infer<typeof PressOutputSchema>;
 // select - Select a dropdown option (no agent_version)
 const SelectInputSchemaBase = z.object({
   /** Stable element ID from find_elements or snapshot */
-  eid: z.string().describe('Element ID of the dropdown from find_elements results or the page snapshot.'),
+  eid: z
+    .string()
+    .describe('Element ID of the dropdown from find_elements results or the page snapshot.'),
   /** Option value or visible text to select */
   value: z
     .string()
@@ -737,9 +737,7 @@ export type SelectOutput = z.infer<typeof SelectOutputSchema>;
 // hover - Hover over an element (no agent_version)
 const HoverInputSchemaBase = z.object({
   /** Stable element ID from find_elements or snapshot */
-  eid: z
-    .string()
-    .describe('Element ID from find_elements results or the page snapshot.'),
+  eid: z.string().describe('Element ID from find_elements results or the page snapshot.'),
   /** Page ID. If omitted, operates on the most recently used page */
   page_id: z.string().optional(),
 });

--- a/src/tools/tool-schemas.ts
+++ b/src/tools/tool-schemas.ts
@@ -527,13 +527,20 @@ export type CaptureSnapshotOutput = z.infer<typeof CaptureSnapshotOutputSchema>;
 export const FindElementsInputSchema = z.object({
   /** Page ID. If omitted, operates on the most recently used page */
   page_id: z.string().optional().describe('The ID of the page to search within.'),
-  /** Filter by semantic type (e.g., 'radio' for form options). */
+  /** Filter by element type. */
   kind: z
     .enum(['button', 'link', 'radio', 'checkbox', 'textbox', 'combobox', 'image', 'heading'])
     .optional()
-    .describe("Filter by semantic type (e.g., 'radio' for form options)."),
-  /** Fuzzy match for visible text or accessible name. */
-  label: z.string().optional().describe('Fuzzy match for visible text or accessible name.'),
+    .describe(
+      "Filter by element type: 'button' for clickable buttons, 'link' for hyperlinks, 'textbox' for input fields, 'checkbox'/'radio' for toggles, 'combobox' for dropdowns, 'heading' for section titles, 'image' for images."
+    ),
+  /** Search text to match against element labels. */
+  label: z
+    .string()
+    .optional()
+    .describe(
+      'Search text to match against element labels - uses case-insensitive substring matching. Example: label "Sign" matches "Sign In", "Sign Up", "Signature".'
+    ),
   /** Restrict search to a specific area. */
   region: z
     .enum(['main', 'nav', 'header', 'footer'])
@@ -541,13 +548,13 @@ export const FindElementsInputSchema = z.object({
     .describe('Restrict search to a specific area.'),
   /** Maximum number of results (default: 10) */
   limit: z.number().int().min(1).max(100).default(10).describe('Number of results to return.'),
-  /** Include non-interactive readable content (text, paragraph, dialog) */
+  /** Include readable content with semantic IDs in results. */
   include_readable: z
     .boolean()
     .default(true)
     .optional()
     .describe(
-      'Include non-interactive readable content (text, heading, paragraph, dialog). These get rd-* IDs.'
+      'When true (default), text content (paragraphs, headings) gets semantic IDs (rd-*) for reference. Set to true when you need to read page content. Use the `kind` parameter to filter to specific element types.'
     ),
 });
 
@@ -558,7 +565,7 @@ export type FindElementsInput = z.infer<typeof FindElementsInputSchema>;
 export type FindElementsOutput = z.infer<typeof FindElementsOutputSchema>;
 
 // ============================================================================
-// get_node_details - Get full details for a specific node
+// get_element_details - Get full details for a specific element
 // ============================================================================
 
 export const GetNodeDetailsInputSchema = z.object({
@@ -579,8 +586,12 @@ export type GetNodeDetailsOutput = z.infer<typeof GetNodeDetailsOutputSchema>;
 // ============================================================================
 
 const ScrollElementIntoViewInputSchemaBase = z.object({
-  /** Stable element ID from actionables list */
-  eid: z.string().describe('The eid of the element to scroll into view.'),
+  /** Stable element ID from find_elements or snapshot */
+  eid: z
+    .string()
+    .describe(
+      'Element ID of the off-screen element from find_elements results or the page snapshot.'
+    ),
   /** Page ID. If omitted, operates on the most recently used page */
   page_id: z.string().optional(),
 });
@@ -639,8 +650,12 @@ export const SupportedKeys = [
 const ClickInputSchemaBase = z.object({
   /** Page ID. If omitted, operates on the most recently used page */
   page_id: z.string().optional().describe('The ID of the page containing the element.'),
-  /** Stable element ID from actionables list */
-  eid: z.string().describe('The internal element ID (eid) from the snapshot.'),
+  /** Stable element ID from find_elements or snapshot */
+  eid: z
+    .string()
+    .describe(
+      'Element ID from find_elements results or the page snapshot. Every interactive element has a unique eid.'
+    ),
 });
 export const ClickInputSchema = ClickInputSchemaBase;
 // Re-export base for .shape access
@@ -656,10 +671,19 @@ export type ClickOutput = z.infer<typeof ClickOutputSchema>;
 const TypeInputSchemaBase = z.object({
   /** Text to type */
   text: z.string().describe('The text to type into the element.'),
-  /** Stable element ID from actionables list */
-  eid: z.string().describe('The eid of the input element.'),
+  /** Stable element ID from find_elements or snapshot */
+  eid: z
+    .string()
+    .describe(
+      'Element ID of the input field from find_elements results or the page snapshot.'
+    ),
   /** Clear existing text before typing (default: false) */
-  clear: z.boolean().default(false).describe('Clear existing text before typing.'),
+  clear: z
+    .boolean()
+    .default(false)
+    .describe(
+      'If true, clear the field before typing (replaces content). If false (default), append to existing text.'
+    ),
   /** Page ID. If omitted, operates on the most recently used page */
   page_id: z.string().optional(),
 });
@@ -690,10 +714,14 @@ export type PressOutput = z.infer<typeof PressOutputSchema>;
 
 // select - Select a dropdown option (no agent_version)
 const SelectInputSchemaBase = z.object({
-  /** Stable element ID from actionables list */
-  eid: z.string().describe('The eid of the <select> element.'),
+  /** Stable element ID from find_elements or snapshot */
+  eid: z.string().describe('Element ID of the dropdown from find_elements results or the page snapshot.'),
   /** Option value or visible text to select */
-  value: z.string().describe('Option value or visible text to select.'),
+  value: z
+    .string()
+    .describe(
+      'The option to select - can be either the value attribute or the visible text of the option.'
+    ),
   /** Page ID. If omitted, operates on the most recently used page */
   page_id: z.string().optional(),
 });
@@ -708,8 +736,10 @@ export type SelectOutput = z.infer<typeof SelectOutputSchema>;
 
 // hover - Hover over an element (no agent_version)
 const HoverInputSchemaBase = z.object({
-  /** Stable element ID from actionables list */
-  eid: z.string().describe('The eid of the element to hover over.'),
+  /** Stable element ID from find_elements or snapshot */
+  eid: z
+    .string()
+    .describe('Element ID from find_elements results or the page snapshot.'),
   /** Page ID. If omitted, operates on the most recently used page */
   page_id: z.string().optional(),
 });

--- a/tests/integration/network-idle.test.ts
+++ b/tests/integration/network-idle.test.ts
@@ -80,7 +80,7 @@ describe.skipIf(skipIntegration)('Network Idle Stabilization (Integration)', () 
 
     // Launch browser
     browser = await puppeteer.launch({ headless: true, channel: 'chrome' });
-  });
+  }, 30000);
 
   afterAll(async () => {
     if (browser) {

--- a/tests/integration/observation-capture.test.ts
+++ b/tests/integration/observation-capture.test.ts
@@ -27,7 +27,7 @@ describe.skipIf(skipIntegration)('Observation Capture Integration', () => {
   beforeAll(async () => {
     browser = await puppeteer.launch({ headless: true, channel: 'chrome' });
     page = await browser.newPage();
-  });
+  }, 30000);
 
   afterAll(async () => {
     await browser?.close();

--- a/tests/unit/tools/navigation-cleanup.test.ts
+++ b/tests/unit/tools/navigation-cleanup.test.ts
@@ -143,7 +143,7 @@ vi.mock('../../../src/tools/response-builder.js', () => ({
   buildClosePageResponse: vi.fn().mockReturnValue({ success: true }),
   buildCloseSessionResponse: vi.fn().mockReturnValue({ success: true }),
   buildFindElementsResponse: vi.fn(),
-  buildGetNodeDetailsResponse: vi.fn(),
+  buildGetElementDetailsResponse: vi.fn(),
 }));
 
 // Import module under test AFTER mocks are set up


### PR DESCRIPTION
## Summary
- Rename `get_node_details` to `get_element_details` for LLM clarity
- Rewrite all 19 tool descriptions with "when to use" guidance
- Improve parameter descriptions for `include_readable`, `kind`, `label`, `eid`, `clear`
- Add accurate matching behavior descriptions (substring vs fuzzy)

## Key Improvements
- **find_elements**: Clarify `include_readable` gives semantic IDs for text content
- **capture_snapshot**: Explain when NOT to use (after action tools)
- **Action tools**: All now mention they return updated snapshots
- **eid params**: Explain they come from find_elements or snapshots
- **label param**: Correctly describes case-insensitive substring matching

## Test plan
- [x] `npm run type-check` passes
- [x] `npm run lint` passes
- [x] `npm test` - all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)