### PR TITLE
fix: sync browser tabs, viewport detection, and overlay layer rendering

### DIFF
--- a/src/tools/browser-tools.ts
+++ b/src/tools/browser-tools.ts
@@ -380,11 +380,15 @@ async function executeNavigationAction(
 /**
  * List all open browser pages with their metadata.
  *
+ * Syncs with browser context to ensure all tabs are registered,
+ * including tabs opened externally or after reconnection.
+ *
  * @returns XML result with page list
  */
-export function listPages(): import('./tool-schemas.js').ListPagesOutput {
+export async function listPages(): Promise<import('./tool-schemas.js').ListPagesOutput> {
   const session = getSessionManager();
-  const pages = session.listPages();
+  // Sync to pick up any unregistered browser tabs
+  const pages = await session.syncPages();
   const pageInfos = pages.map((h) => ({
     page_id: h.page_id,
     url: h.url ?? '',

--- a/tests/unit/tools/list-pages.test.ts
+++ b/tests/unit/tools/list-pages.test.ts
@@ -7,9 +7,9 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { SessionManager } from '../../../src/browser/session-manager.js';
 
 // Mock session manager
-const mockListPages = vi.fn();
+const mockSyncPages = vi.fn();
 const mockSessionManager = {
-  listPages: mockListPages,
+  syncPages: mockSyncPages,
 } as unknown as SessionManager;
 
 vi.mock('../../../src/browser/session-manager.js', () => ({}));
@@ -85,11 +85,11 @@ describe('listPages', () => {
     vi.clearAllMocks();
   });
 
-  it('should return empty pages list when no pages are registered', () => {
-    mockListPages.mockReturnValue([]);
+  it('should return empty pages list when no pages are registered', async () => {
+    mockSyncPages.mockResolvedValue([]);
     initializeTools(mockSessionManager);
 
-    const result = listPages();
+    const result = await listPages();
 
     expect(result).toContain('type="list_pages"');
     expect(result).toContain('status="success"');
@@ -97,8 +97,8 @@ describe('listPages', () => {
     expect(result).not.toContain('<page ');
   });
 
-  it('should return correct metadata for multiple pages', () => {
-    mockListPages.mockReturnValue([
+  it('should return correct metadata for multiple pages', async () => {
+    mockSyncPages.mockResolvedValue([
       {
         page_id: 'page-abc',
         url: 'https://example.com',
@@ -118,7 +118,7 @@ describe('listPages', () => {
     ]);
     initializeTools(mockSessionManager);
 
-    const result = listPages();
+    const result = await listPages();
 
     expect(result).toContain('count="2"');
     expect(result).toContain('page_id="page-abc"');
@@ -129,8 +129,8 @@ describe('listPages', () => {
     expect(result).toContain('title="Other Site"');
   });
 
-  it('should handle pages with missing url and title', () => {
-    mockListPages.mockReturnValue([
+  it('should handle pages with missing url and title', async () => {
+    mockSyncPages.mockResolvedValue([
       {
         page_id: 'page-new',
         page: {},
@@ -140,7 +140,7 @@ describe('listPages', () => {
     ]);
     initializeTools(mockSessionManager);
 
-    const result = listPages();
+    const result = await listPages();
 
     expect(result).toContain('count="1"');
     expect(result).toContain('page_id="page-new"');
@@ -148,8 +148,8 @@ describe('listPages', () => {
     expect(result).toContain('title=""');
   });
 
-  it('should escape XML special characters in page metadata', () => {
-    mockListPages.mockReturnValue([
+  it('should escape XML special characters in page metadata', async () => {
+    mockSyncPages.mockResolvedValue([
       {
         page_id: 'page-special',
         url: 'https://example.com?foo=1&bar=2',
@@ -161,7 +161,7 @@ describe('listPages', () => {
     ]);
     initializeTools(mockSessionManager);
 
-    const result = listPages();
+    const result = await listPages();
 
     expect(result).toContain('&amp;');
     expect(result).toContain('&lt;Page&gt;');


### PR DESCRIPTION
## Summary
- Add `syncPages()` method to adopt unregistered browser tabs after reconnection or when external tabs are opened
- Fix viewport detection for external browsers by using CDP `Page.getLayoutMetrics` when `page.viewport()` returns null
- Show all actionables in overlay layers (modal/popover/drawer) regardless of diff mode, ensuring users can interact with modal content

## Test plan
- [x] TypeScript type-check passes
- [x] ESLint passes
- [x] All 1423 unit tests pass
- [x] Manual testing: opened Bootstrap modal demo, verified modal elements appear in `capture_snapshot`
- [x] Manual testing: verified `list_pages` returns all browser tabs after reconnection

🤖 Generated with [Claude Code](https://claude.com/claude-code)