### PR TITLE
feat: add take_screenshot MCP tool

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,11 +6,11 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Agent Web Interface is an MCP (Model Context Protocol) server for AI-powered browser automation via Puppeteer and CDP (Chrome DevTools Protocol). It provides **semantic page snapshots** - compact, structured representations designed for LLM consumption with stable element IDs that survive DOM mutations.
 
-**19 Tools** across 6 categories:
+**20 Tools** across 6 categories:
 
 - **Session**: list_tabs, close_page, close_session
 - **Navigation**: navigate, go_back, go_forward, reload
-- **Observation**: capture_snapshot, find_elements, get_element_details
+- **Observation**: capture_snapshot, find_elements, get_element_details, take_screenshot
 - **Interaction**: click, type, press, select, hover, scroll_element_into_view, scroll_page
 - **Form Understanding**: get_form_understanding, get_field_context
 
@@ -121,7 +121,11 @@ src/
 ├── tools/
 │   ├── browser-tools.ts         # Tool handler implementations
 │   ├── execute-action.ts        # Action execution with retry
-│   └── tool-schemas.ts          # Zod input schemas
+│   ├── tool-schemas.ts          # Zod input schemas
+│   └── tool-result.types.ts     # ImageResult/FileResult types
+├── screenshot/
+│   ├── screenshot-capture.ts    # CDP screenshot capture + bounding box
+│   └── index.ts                 # Barrel export
 ├── snapshot/
 │   ├── snapshot-compiler.ts     # Orchestrates extractors
 │   └── extractors/              # Modular extraction algorithms
@@ -138,7 +142,8 @@ src/
 │   └── xml-renderer.ts          # XML output rendering
 ├── delta/
 │   └── dom-stabilizer.ts        # Stabilize DOM after actions
-├── lib/                         # Reusable algorithms
+├── lib/
+│   └── temp-file.ts             # Temp file utility for large results
 └── shared/                      # Types, services, errors
 
 tests/

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ import {
   hover,
   getFormUnderstanding,
   getFieldContext,
+  takeScreenshot,
   // Input schemas only (all outputs are XML strings now)
   ListPagesInputSchema,
   ClosePageInputSchema,
@@ -60,6 +61,7 @@ import {
   HoverInputSchemaBase,
   GetFormUnderstandingInputSchema,
   GetFieldContextInputSchema,
+  TakeScreenshotInputSchemaBase,
 } from './tools/index.js';
 
 /**
@@ -238,6 +240,17 @@ function initializeServer(): BrowserAutomationServer {
       inputSchema: GetNodeDetailsInputSchema.shape,
     },
     withLazyInit(getNodeDetails, 'get_element_details')
+  );
+
+  server.registerTool(
+    'take_screenshot',
+    {
+      title: 'Take Screenshot',
+      description:
+        'Capture a screenshot of the current page or a specific element. Returns the image directly for small screenshots (<2MB) or saves to a temp file for large ones. Use `eid` for element screenshots (requires a prior snapshot) or `fullPage: true` for full-page capture. Supports PNG (lossless, default) and JPEG (lossy with quality 0-100). Cannot combine eid and fullPage.',
+      inputSchema: TakeScreenshotInputSchemaBase.shape,
+    },
+    withLazyInit(takeScreenshot, 'take_screenshot')
   );
 
   // ============================================================================

--- a/src/lib/temp-file.ts
+++ b/src/lib/temp-file.ts
@@ -1,0 +1,58 @@
+/**
+ * Temp File Utility
+ *
+ * Writes binary data to temporary files with unique names.
+ * Used when tool results are too large for inline MCP responses.
+ */
+
+import { writeFile, unlink } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { randomBytes } from 'crypto';
+
+/** Tracks all temp files created during the session */
+const trackedFiles = new Set<string>();
+
+/**
+ * Write base64-encoded data to a temporary file.
+ *
+ * @param base64Data - Base64-encoded file content
+ * @param extension - File extension without dot (e.g., 'png', 'jpg')
+ * @returns Absolute path to the written file
+ */
+export async function writeTempFile(base64Data: string, extension: string): Promise<string> {
+  const buffer = Buffer.from(base64Data, 'base64');
+  const filename = `screenshot-${randomBytes(6).toString('hex')}.${extension}`;
+  const filepath = join(tmpdir(), filename);
+
+  await writeFile(filepath, buffer);
+  trackedFiles.add(filepath);
+  return filepath;
+}
+
+/**
+ * Compute the byte size of base64-encoded data.
+ *
+ * @param base64 - Base64-encoded string
+ * @returns Size in bytes
+ */
+export function computeBase64ByteSize(base64: string): number {
+  let size = Math.floor((base64.length * 3) / 4);
+  if (base64.endsWith('==')) size -= 2;
+  else if (base64.endsWith('=')) size -= 1;
+  return size;
+}
+
+/**
+ * Clean up all temp files created during this session.
+ * Silently ignores files that have already been deleted.
+ */
+export async function cleanupTempFiles(): Promise<void> {
+  const deletions = [...trackedFiles].map((filepath) =>
+    unlink(filepath).catch(() => {
+      /* already deleted or inaccessible — ignore */
+    })
+  );
+  await Promise.all(deletions);
+  trackedFiles.clear();
+}

--- a/src/screenshot/index.ts
+++ b/src/screenshot/index.ts
@@ -1,0 +1,10 @@
+/**
+ * Screenshot Module
+ *
+ * Browser screenshot capture via CDP.
+ *
+ * @module screenshot
+ */
+
+export { captureScreenshot, getElementBoundingBox } from './screenshot-capture.js';
+export type { ScreenshotOptions } from './screenshot-capture.js';

--- a/src/screenshot/screenshot-capture.ts
+++ b/src/screenshot/screenshot-capture.ts
@@ -1,0 +1,124 @@
+/**
+ * Screenshot Capture Service
+ *
+ * Captures browser screenshots via CDP with support for:
+ * - Viewport screenshots (default)
+ * - Full page screenshots (beyond viewport)
+ * - Element screenshots (clipped to bounding box)
+ * - PNG and JPEG formats with quality control
+ * - Size-based inline vs file storage (2MB threshold)
+ *
+ * Uses `optimizeForSpeed: true` for faster encoding (matches chrome-devtools-mcp).
+ */
+
+import type { CdpClient } from '../cdp/cdp-client.interface.js';
+import type { Protocol } from 'devtools-protocol';
+import { writeTempFile, computeBase64ByteSize } from '../lib/temp-file.js';
+import type { ImageResult, FileResult } from '../tools/tool-result.types.js';
+
+/** Screenshots under this size are returned inline as base64 */
+const INLINE_SIZE_THRESHOLD_BYTES = 2 * 1024 * 1024; // 2MB
+
+export interface ScreenshotOptions {
+  /** Image format (default: 'png') */
+  format?: 'png' | 'jpeg';
+  /** JPEG quality 0-100 (ignored for PNG) */
+  quality?: number;
+  /** Use faster encoding at cost of larger file size (default: true) */
+  optimizeForSpeed?: boolean;
+  /** Clip to specific viewport region (for element screenshots) */
+  clip?: Protocol.Page.Viewport;
+  /** Capture full page beyond visible viewport (default: false) */
+  captureBeyondViewport?: boolean;
+}
+
+/**
+ * Capture a screenshot via CDP `Page.captureScreenshot`.
+ *
+ * Returns an `ImageResult` (inline base64) if under 2MB,
+ * or a `FileResult` (temp file path) if 2MB or larger.
+ *
+ * @param cdp - CDP client for the target page
+ * @param options - Screenshot configuration
+ * @returns Image result for inline delivery, or file result for large screenshots
+ */
+export async function captureScreenshot(
+  cdp: CdpClient,
+  options: ScreenshotOptions = {}
+): Promise<ImageResult | FileResult> {
+  const format = options.format ?? 'png';
+  const mimeType = format === 'jpeg' ? 'image/jpeg' : 'image/png';
+
+  const params: Protocol.Page.CaptureScreenshotRequest = {
+    format,
+    quality: format === 'jpeg' ? (options.quality ?? 80) : undefined,
+    optimizeForSpeed: options.optimizeForSpeed ?? true,
+    captureBeyondViewport: options.captureBeyondViewport ?? false,
+  };
+
+  if (options.clip) {
+    params.clip = options.clip;
+  }
+
+  const response = await cdp.send('Page.captureScreenshot', params);
+  const base64Data = response.data;
+  const sizeBytes = computeBase64ByteSize(base64Data);
+
+  if (sizeBytes < INLINE_SIZE_THRESHOLD_BYTES) {
+    return {
+      type: 'image',
+      data: base64Data,
+      mimeType,
+      sizeBytes,
+    };
+  }
+
+  const extension = format === 'jpeg' ? 'jpg' : 'png';
+  const path = await writeTempFile(base64Data, extension);
+
+  return {
+    type: 'file',
+    path,
+    mimeType,
+    sizeBytes,
+  };
+}
+
+/**
+ * Get the bounding box of an element for clipped screenshots.
+ *
+ * Uses CDP `DOM.getBoxModel` to retrieve the content box coordinates.
+ *
+ * @param cdp - CDP client
+ * @param backendNodeId - CDP backend node ID of the target element
+ * @returns Viewport clip region suitable for `Page.captureScreenshot`
+ * @throws Error if element has no box model (e.g., `display: none`)
+ */
+export async function getElementBoundingBox(
+  cdp: CdpClient,
+  backendNodeId: number
+): Promise<Protocol.Page.Viewport> {
+  const response = await cdp.send('DOM.getBoxModel', { backendNodeId });
+
+  if (!response.model) {
+    throw new Error(`Element (backendNodeId=${backendNodeId}) has no box model — it may be hidden`);
+  }
+
+  // Content quad: [x1,y1, x2,y2, x3,y3, x4,y4]
+  // For axis-aligned elements: Top-left, Top-right, Bottom-right, Bottom-left
+  // For transformed elements (CSS rotate, etc.): corners may not be axis-aligned,
+  // so we compute the axis-aligned bounding box from all 4 corner points.
+  const q = response.model.content;
+  const xs = [q[0], q[2], q[4], q[6]];
+  const ys = [q[1], q[3], q[5], q[7]];
+  const minX = Math.min(...xs);
+  const minY = Math.min(...ys);
+
+  return {
+    x: Math.round(minX),
+    y: Math.round(minY),
+    width: Math.round(Math.max(...xs) - minX),
+    height: Math.round(Math.max(...ys) - minY),
+    scale: 1,
+  };
+}

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -25,6 +25,7 @@ export {
   press,
   select,
   hover,
+  takeScreenshot,
 } from './browser-tools.js';
 
 // Server config - lazy browser initialization
@@ -122,7 +123,22 @@ export {
   HoverOutputSchema,
   type HoverInput,
   type HoverOutput,
+  // take_screenshot
+  TakeScreenshotInputSchema,
+  TakeScreenshotInputSchemaBase,
+  TakeScreenshotOutputSchema,
+  type TakeScreenshotInput,
+  type TakeScreenshotOutput,
 } from './tool-schemas.js';
+
+// Tool result types
+export {
+  isImageResult,
+  isFileResult,
+  type ImageResult,
+  type FileResult,
+  type ToolResult,
+} from './tool-result.types.js';
 
 // Form tools
 export {

--- a/src/tools/tool-result.types.ts
+++ b/src/tools/tool-result.types.ts
@@ -1,0 +1,68 @@
+/**
+ * Tool Result Types
+ *
+ * Discriminated union for tool results that go beyond plain text.
+ * Enables the MCP server to return different content types (text, image, file)
+ * while keeping tool handlers decoupled from MCP protocol details.
+ */
+
+/**
+ * Image result - returned inline as MCP ImageContent (base64).
+ * Used when image data is small enough to embed directly (<2MB).
+ */
+export interface ImageResult {
+  readonly type: 'image';
+  /** Base64-encoded image data */
+  readonly data: string;
+  /** MIME type (e.g., 'image/png', 'image/jpeg') */
+  readonly mimeType: string;
+  /** Size in bytes */
+  readonly sizeBytes: number;
+}
+
+/**
+ * File result - returned as a text message with file path.
+ * Used when image data is too large for inline embedding (>=2MB).
+ */
+export interface FileResult {
+  readonly type: 'file';
+  /** Absolute path to the saved file */
+  readonly path: string;
+  /** MIME type of the saved file */
+  readonly mimeType: string;
+  /** Size in bytes */
+  readonly sizeBytes: number;
+}
+
+/**
+ * Discriminated union of all non-text tool result types.
+ */
+export type ToolResult = ImageResult | FileResult;
+
+/**
+ * Type guard for ImageResult.
+ */
+export function isImageResult(result: unknown): result is ImageResult {
+  return (
+    typeof result === 'object' &&
+    result !== null &&
+    'type' in result &&
+    (result as Record<string, unknown>).type === 'image' &&
+    'data' in result &&
+    'mimeType' in result
+  );
+}
+
+/**
+ * Type guard for FileResult.
+ */
+export function isFileResult(result: unknown): result is FileResult {
+  return (
+    typeof result === 'object' &&
+    result !== null &&
+    'type' in result &&
+    (result as Record<string, unknown>).type === 'file' &&
+    'path' in result &&
+    'mimeType' in result
+  );
+}

--- a/src/tools/tool-schemas.ts
+++ b/src/tools/tool-schemas.ts
@@ -749,3 +749,63 @@ export const HoverOutputSchema = z.string();
 
 export type HoverInput = z.infer<typeof HoverInputSchema>;
 export type HoverOutput = z.infer<typeof HoverOutputSchema>;
+
+// ============================================================================
+// take_screenshot - Capture page or element screenshot
+// ============================================================================
+
+// Base schema without refinement (for .shape access in tool registration)
+const TakeScreenshotInputSchemaBase = z.object({
+  /** Page ID. If omitted, operates on the most recently used page */
+  page_id: z.string().optional().describe('The ID of the page to screenshot.'),
+  /** Element ID to capture (requires prior snapshot). Cannot combine with fullPage. */
+  eid: z
+    .string()
+    .optional()
+    .describe(
+      'Element ID to screenshot. Requires a prior snapshot. Cannot be combined with fullPage.'
+    ),
+  /** Capture full page beyond viewport. Cannot combine with eid. */
+  fullPage: z
+    .boolean()
+    .default(false)
+    .optional()
+    .describe('Capture full page height beyond the viewport. Cannot be combined with eid.'),
+  /** Image format (default: png) */
+  format: z
+    .enum(['png', 'jpeg'])
+    .default('png')
+    .optional()
+    .describe("Image format: 'png' (lossless, default) or 'jpeg' (lossy with quality control)."),
+  /** JPEG quality 0-100 (ignored for PNG) */
+  quality: z
+    .number()
+    .int()
+    .min(0)
+    .max(100)
+    .optional()
+    .describe('JPEG quality 0-100. Only applies when format is jpeg.'),
+});
+
+export const TakeScreenshotInputSchema = TakeScreenshotInputSchemaBase;
+export { TakeScreenshotInputSchemaBase };
+
+export type TakeScreenshotInput = z.infer<typeof TakeScreenshotInputSchema>;
+
+/** Discriminated union output: inline image or file path */
+export const TakeScreenshotOutputSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('image'),
+    data: z.string(),
+    mimeType: z.string(),
+    sizeBytes: z.number(),
+  }),
+  z.object({
+    type: z.literal('file'),
+    path: z.string(),
+    mimeType: z.string(),
+    sizeBytes: z.number(),
+  }),
+]);
+
+export type TakeScreenshotOutput = z.infer<typeof TakeScreenshotOutputSchema>;

--- a/tests/unit/lib/temp-file.test.ts
+++ b/tests/unit/lib/temp-file.test.ts
@@ -13,7 +13,11 @@ vi.mock('crypto', () => ({
   randomBytes: vi.fn().mockReturnValue({ toString: () => 'a1b2c3d4e5f6' }),
 }));
 
-import { writeTempFile, computeBase64ByteSize, cleanupTempFiles } from '../../../src/lib/temp-file.js';
+import {
+  writeTempFile,
+  computeBase64ByteSize,
+  cleanupTempFiles,
+} from '../../../src/lib/temp-file.js';
 import { writeFile, unlink } from 'fs/promises';
 import { tmpdir } from 'os';
 import { join } from 'path';

--- a/tests/unit/lib/temp-file.test.ts
+++ b/tests/unit/lib/temp-file.test.ts
@@ -1,0 +1,110 @@
+/**
+ * Temp File Utility Tests
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock fs/promises and crypto (hoisted)
+vi.mock('fs/promises', () => ({
+  writeFile: vi.fn().mockResolvedValue(undefined),
+  unlink: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('crypto', () => ({
+  randomBytes: vi.fn().mockReturnValue({ toString: () => 'a1b2c3d4e5f6' }),
+}));
+
+import { writeTempFile, computeBase64ByteSize, cleanupTempFiles } from '../../../src/lib/temp-file.js';
+import { writeFile, unlink } from 'fs/promises';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+describe('writeTempFile', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should write decoded base64 data to a temp file', async () => {
+    const base64 = Buffer.from('hello world').toString('base64');
+    const filepath = await writeTempFile(base64, 'png');
+
+    expect(writeFile).toHaveBeenCalledWith(
+      expect.stringContaining('screenshot-'),
+      expect.any(Buffer)
+    );
+    expect(filepath).toContain('.png');
+  });
+
+  it('should generate path in OS temp directory', async () => {
+    const filepath = await writeTempFile('dGVzdA==', 'jpg');
+
+    expect(filepath).toBe(join(tmpdir(), 'screenshot-a1b2c3d4e5f6.jpg'));
+  });
+
+  it('should use the provided extension', async () => {
+    const filepath = await writeTempFile('dGVzdA==', 'jpg');
+    expect(filepath).toMatch(/\.jpg$/);
+  });
+});
+
+describe('computeBase64ByteSize', () => {
+  it('should compute correct size for data without padding', () => {
+    // "abc" in base64 is "YWJj" (4 chars, no padding, 3 bytes)
+    expect(computeBase64ByteSize('YWJj')).toBe(3);
+  });
+
+  it('should account for single padding character', () => {
+    // "ab" in base64 is "YWI=" (4 chars, 1 padding, 2 bytes)
+    expect(computeBase64ByteSize('YWI=')).toBe(2);
+  });
+
+  it('should account for double padding characters', () => {
+    // "a" in base64 is "YQ==" (4 chars, 2 padding, 1 byte)
+    expect(computeBase64ByteSize('YQ==')).toBe(1);
+  });
+
+  it('should handle empty string', () => {
+    expect(computeBase64ByteSize('')).toBe(0);
+  });
+
+  it('should handle large strings correctly', () => {
+    // 1000 base64 chars = ~750 bytes (before padding adjustment)
+    const size = computeBase64ByteSize('A'.repeat(1000));
+    expect(size).toBe(750);
+  });
+});
+
+describe('cleanupTempFiles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should delete all tracked temp files', async () => {
+    // Create files so they get tracked
+    await writeTempFile('dGVzdA==', 'png');
+    await writeTempFile('dGVzdA==', 'jpg');
+
+    await cleanupTempFiles();
+
+    expect(unlink).toHaveBeenCalledTimes(2);
+  });
+
+  it('should clear tracking set after cleanup', async () => {
+    await writeTempFile('dGVzdA==', 'png');
+    await cleanupTempFiles();
+
+    vi.mocked(unlink).mockClear();
+
+    // Second cleanup should have nothing to delete
+    await cleanupTempFiles();
+    expect(unlink).not.toHaveBeenCalled();
+  });
+
+  it('should silently ignore already-deleted files', async () => {
+    vi.mocked(unlink).mockRejectedValue(new Error('ENOENT'));
+
+    await writeTempFile('dGVzdA==', 'png');
+
+    // Should not throw
+    await expect(cleanupTempFiles()).resolves.toBeUndefined();
+  });
+});

--- a/tests/unit/screenshot/screenshot-capture.test.ts
+++ b/tests/unit/screenshot/screenshot-capture.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Screenshot Capture Service Tests
+ */
+/* eslint-disable @typescript-eslint/unbound-method */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { CdpClient } from '../../../src/cdp/cdp-client.interface.js';
+
+// Mock temp-file module (hoisted before imports)
+vi.mock('../../../src/lib/temp-file.js', () => ({
+  writeTempFile: vi.fn().mockResolvedValue('/tmp/screenshot-abc123.png'),
+  computeBase64ByteSize: vi.fn((b64: string) => Math.floor((b64.length * 3) / 4)),
+}));
+
+import { captureScreenshot, getElementBoundingBox } from '../../../src/screenshot/screenshot-capture.js';
+import { writeTempFile, computeBase64ByteSize } from '../../../src/lib/temp-file.js';
+
+function createMockCdp(): CdpClient {
+  return {
+    send: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+    once: vi.fn(),
+    close: vi.fn().mockResolvedValue(undefined),
+    isActive: vi.fn().mockReturnValue(true),
+  };
+}
+
+describe('captureScreenshot', () => {
+  let cdp: CdpClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cdp = createMockCdp();
+  });
+
+  it('should return inline ImageResult for small screenshots', async () => {
+    const smallBase64 = 'iVBORw0KGgoAAAANSUhEUg==';
+    vi.mocked(cdp.send).mockResolvedValue({ data: smallBase64 });
+    vi.mocked(computeBase64ByteSize).mockReturnValue(1024); // 1KB
+
+    const result = await captureScreenshot(cdp);
+
+    expect(result.type).toBe('image');
+    expect(result).toHaveProperty('data', smallBase64);
+    expect(result.mimeType).toBe('image/png');
+    expect(result.sizeBytes).toBe(1024);
+  });
+
+  it('should return FileResult for large screenshots (>=2MB)', async () => {
+    const largeBase64 = 'A'.repeat(3_000_000);
+    vi.mocked(cdp.send).mockResolvedValue({ data: largeBase64 });
+    vi.mocked(computeBase64ByteSize).mockReturnValue(2.5 * 1024 * 1024); // 2.5MB
+
+    const result = await captureScreenshot(cdp);
+
+    expect(result.type).toBe('file');
+    expect(result).toHaveProperty('path');
+    expect(result.mimeType).toBe('image/png');
+    expect(writeTempFile).toHaveBeenCalledWith(largeBase64, 'png');
+  });
+
+  it('should use PNG format by default with optimizeForSpeed', async () => {
+    vi.mocked(cdp.send).mockResolvedValue({ data: 'abc' });
+    vi.mocked(computeBase64ByteSize).mockReturnValue(3);
+
+    await captureScreenshot(cdp);
+
+    expect(cdp.send).toHaveBeenCalledWith('Page.captureScreenshot', {
+      format: 'png',
+      quality: undefined,
+      optimizeForSpeed: true,
+      captureBeyondViewport: false,
+    });
+  });
+
+  it('should pass JPEG quality parameter', async () => {
+    vi.mocked(cdp.send).mockResolvedValue({ data: 'abc' });
+    vi.mocked(computeBase64ByteSize).mockReturnValue(3);
+
+    await captureScreenshot(cdp, { format: 'jpeg', quality: 75 });
+
+    expect(cdp.send).toHaveBeenCalledWith('Page.captureScreenshot', {
+      format: 'jpeg',
+      quality: 75,
+      optimizeForSpeed: true,
+      captureBeyondViewport: false,
+    });
+  });
+
+  it('should default JPEG quality to 80 when not specified', async () => {
+    vi.mocked(cdp.send).mockResolvedValue({ data: 'abc' });
+    vi.mocked(computeBase64ByteSize).mockReturnValue(3);
+
+    await captureScreenshot(cdp, { format: 'jpeg' });
+
+    expect(cdp.send).toHaveBeenCalledWith(
+      'Page.captureScreenshot',
+      expect.objectContaining({ quality: 80 })
+    );
+  });
+
+  it('should use correct mimeType for JPEG', async () => {
+    vi.mocked(cdp.send).mockResolvedValue({ data: 'abc' });
+    vi.mocked(computeBase64ByteSize).mockReturnValue(3);
+
+    const result = await captureScreenshot(cdp, { format: 'jpeg' });
+
+    expect(result.mimeType).toBe('image/jpeg');
+  });
+
+  it('should save JPEG files with .jpg extension', async () => {
+    const largeBase64 = 'A'.repeat(3_000_000);
+    vi.mocked(cdp.send).mockResolvedValue({ data: largeBase64 });
+    vi.mocked(computeBase64ByteSize).mockReturnValue(3 * 1024 * 1024);
+
+    await captureScreenshot(cdp, { format: 'jpeg' });
+
+    expect(writeTempFile).toHaveBeenCalledWith(largeBase64, 'jpg');
+  });
+
+  it('should include clip parameter for element screenshots', async () => {
+    vi.mocked(cdp.send).mockResolvedValue({ data: 'abc' });
+    vi.mocked(computeBase64ByteSize).mockReturnValue(3);
+
+    const clip = { x: 10, y: 20, width: 100, height: 50, scale: 1 };
+    await captureScreenshot(cdp, { clip });
+
+    expect(cdp.send).toHaveBeenCalledWith(
+      'Page.captureScreenshot',
+      expect.objectContaining({ clip })
+    );
+  });
+
+  it('should set captureBeyondViewport for full page screenshots', async () => {
+    vi.mocked(cdp.send).mockResolvedValue({ data: 'abc' });
+    vi.mocked(computeBase64ByteSize).mockReturnValue(3);
+
+    await captureScreenshot(cdp, { captureBeyondViewport: true });
+
+    expect(cdp.send).toHaveBeenCalledWith(
+      'Page.captureScreenshot',
+      expect.objectContaining({ captureBeyondViewport: true })
+    );
+  });
+
+  it('should respect optimizeForSpeed=false', async () => {
+    vi.mocked(cdp.send).mockResolvedValue({ data: 'abc' });
+    vi.mocked(computeBase64ByteSize).mockReturnValue(3);
+
+    await captureScreenshot(cdp, { optimizeForSpeed: false });
+
+    expect(cdp.send).toHaveBeenCalledWith(
+      'Page.captureScreenshot',
+      expect.objectContaining({ optimizeForSpeed: false })
+    );
+  });
+});
+
+describe('getElementBoundingBox', () => {
+  let cdp: CdpClient;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cdp = createMockCdp();
+  });
+
+  it('should return correct bounding box from box model content quad', async () => {
+    // Content quad: top-left(10,20), top-right(110,20), bottom-right(110,70), bottom-left(10,70)
+    vi.mocked(cdp.send).mockResolvedValue({
+      model: {
+        content: [10, 20, 110, 20, 110, 70, 10, 70],
+      },
+    });
+
+    const bbox = await getElementBoundingBox(cdp, 123);
+
+    expect(bbox).toEqual({
+      x: 10,
+      y: 20,
+      width: 100,
+      height: 50,
+      scale: 1,
+    });
+  });
+
+  it('should round fractional coordinates', async () => {
+    vi.mocked(cdp.send).mockResolvedValue({
+      model: {
+        content: [10.4, 20.7, 110.6, 20.7, 110.6, 70.3, 10.4, 70.3],
+      },
+    });
+
+    const bbox = await getElementBoundingBox(cdp, 456);
+
+    expect(bbox.x).toBe(10);
+    expect(bbox.y).toBe(21);
+    expect(bbox.width).toBe(100);
+    expect(bbox.height).toBe(50);
+  });
+
+  it('should compute axis-aligned bounding box for rotated elements', async () => {
+    // Diamond shape (rotated square): corners not axis-aligned
+    // Top(50,0), Right(100,50), Bottom(50,100), Left(0,50)
+    vi.mocked(cdp.send).mockResolvedValue({
+      model: {
+        content: [50, 0, 100, 50, 50, 100, 0, 50],
+      },
+    });
+
+    const bbox = await getElementBoundingBox(cdp, 999);
+
+    expect(bbox).toEqual({
+      x: 0,
+      y: 0,
+      width: 100,
+      height: 100,
+      scale: 1,
+    });
+  });
+
+  it('should throw when element has no box model', async () => {
+    vi.mocked(cdp.send).mockResolvedValue({ model: null });
+
+    await expect(getElementBoundingBox(cdp, 789)).rejects.toThrow(
+      'has no box model'
+    );
+  });
+
+  it('should call DOM.getBoxModel with backendNodeId', async () => {
+    vi.mocked(cdp.send).mockResolvedValue({
+      model: { content: [0, 0, 100, 0, 100, 50, 0, 50] },
+    });
+
+    await getElementBoundingBox(cdp, 42);
+
+    expect(cdp.send).toHaveBeenCalledWith('DOM.getBoxModel', { backendNodeId: 42 });
+  });
+});

--- a/tests/unit/screenshot/screenshot-capture.test.ts
+++ b/tests/unit/screenshot/screenshot-capture.test.ts
@@ -11,7 +11,10 @@ vi.mock('../../../src/lib/temp-file.js', () => ({
   computeBase64ByteSize: vi.fn((b64: string) => Math.floor((b64.length * 3) / 4)),
 }));
 
-import { captureScreenshot, getElementBoundingBox } from '../../../src/screenshot/screenshot-capture.js';
+import {
+  captureScreenshot,
+  getElementBoundingBox,
+} from '../../../src/screenshot/screenshot-capture.js';
 import { writeTempFile, computeBase64ByteSize } from '../../../src/lib/temp-file.js';
 
 function createMockCdp(): CdpClient {
@@ -221,9 +224,7 @@ describe('getElementBoundingBox', () => {
   it('should throw when element has no box model', async () => {
     vi.mocked(cdp.send).mockResolvedValue({ model: null });
 
-    await expect(getElementBoundingBox(cdp, 789)).rejects.toThrow(
-      'has no box model'
-    );
+    await expect(getElementBoundingBox(cdp, 789)).rejects.toThrow('has no box model');
   });
 
   it('should call DOM.getBoxModel with backendNodeId', async () => {

--- a/tests/unit/tools/list-pages.test.ts
+++ b/tests/unit/tools/list-pages.test.ts
@@ -78,6 +78,15 @@ vi.mock('../../../src/query/query-engine.js', () => ({
   QueryEngine: vi.fn(),
 }));
 
+vi.mock('../../../src/screenshot/index.js', () => ({
+  captureScreenshot: vi.fn(),
+  getElementBoundingBox: vi.fn(),
+}));
+
+vi.mock('../../../src/lib/temp-file.js', () => ({
+  cleanupTempFiles: vi.fn().mockResolvedValue(undefined),
+}));
+
 import { initializeTools, listPages } from '../../../src/tools/browser-tools.js';
 
 describe('listPages', () => {

--- a/tests/unit/tools/take-screenshot.test.ts
+++ b/tests/unit/tools/take-screenshot.test.ts
@@ -1,0 +1,266 @@
+/**
+ * take_screenshot Tool Handler Tests
+ */
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { SessionManager } from '../../../src/browser/session-manager.js';
+
+// ============================================================================
+// Hoisted mocks (accessible inside vi.mock factories)
+// ============================================================================
+
+const {
+  mockResolvePage,
+  mockTouchPage,
+  mockStoreGetByPageId,
+  mockGetStateManager,
+  mockCaptureScreenshot,
+  mockGetElementBoundingBox,
+} = vi.hoisted(() => ({
+  mockResolvePage: vi.fn(),
+  mockTouchPage: vi.fn(),
+  mockStoreGetByPageId: vi.fn(),
+  mockGetStateManager: vi.fn(),
+  mockCaptureScreenshot: vi.fn(),
+  mockGetElementBoundingBox: vi.fn(),
+}));
+
+const mockSessionManager = {
+  resolvePage: mockResolvePage,
+  touchPage: mockTouchPage,
+} as unknown as SessionManager;
+
+// ============================================================================
+// Module mocks
+// ============================================================================
+
+vi.mock('../../../src/browser/session-manager.js', () => ({}));
+
+vi.mock('../../../src/form/index.js', () => ({
+  getDependencyTracker: vi.fn(() => ({
+    clearPage: vi.fn(),
+    clearAll: vi.fn(),
+  })),
+}));
+
+vi.mock('../../../src/snapshot/index.js', () => {
+  const SnapshotStore = class {
+    store = vi.fn();
+    getByPageId = mockStoreGetByPageId;
+    removeByPageId = vi.fn();
+    clear = vi.fn();
+  };
+  return {
+    SnapshotStore,
+    clickByBackendNodeId: vi.fn(),
+    typeByBackendNodeId: vi.fn(),
+    pressKey: vi.fn(),
+    selectOption: vi.fn(),
+    hoverByBackendNodeId: vi.fn(),
+    scrollIntoView: vi.fn(),
+    scrollPage: vi.fn(),
+  };
+});
+
+vi.mock('../../../src/snapshot/snapshot-health.js', () => ({
+  captureWithStabilization: vi.fn(),
+  determineHealthCode: vi.fn(),
+}));
+
+vi.mock('../../../src/observation/index.js', () => ({
+  observationAccumulator: {
+    inject: vi.fn(),
+    getAccumulatedObservations: vi.fn(),
+    filterBySignificance: vi.fn(),
+  },
+}));
+
+vi.mock('../../../src/tools/execute-action.js', () => ({
+  executeAction: vi.fn(),
+  executeActionWithRetry: vi.fn(),
+  executeActionWithOutcome: vi.fn(),
+  stabilizeAfterNavigation: vi.fn(),
+  getStateManager: mockGetStateManager,
+  removeStateManager: vi.fn(),
+  clearAllStateManagers: vi.fn(),
+}));
+
+vi.mock('../../../src/state/element-identity.js', () => ({
+  computeEid: vi.fn(),
+}));
+
+vi.mock('../../../src/state/health.types.js', () => ({
+  createHealthyRuntime: vi.fn(),
+  createRecoveredCdpRuntime: vi.fn(),
+}));
+
+vi.mock('../../../src/query/query-engine.js', () => ({
+  QueryEngine: vi.fn(),
+}));
+
+vi.mock('../../../src/screenshot/index.js', () => ({
+  captureScreenshot: mockCaptureScreenshot,
+  getElementBoundingBox: mockGetElementBoundingBox,
+}));
+
+vi.mock('../../../src/lib/temp-file.js', () => ({
+  cleanupTempFiles: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { initializeTools, takeScreenshot } from '../../../src/tools/browser-tools.js';
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('takeScreenshot', () => {
+  const mockCdp = {
+    send: vi.fn(),
+    on: vi.fn(),
+    off: vi.fn(),
+    once: vi.fn(),
+    close: vi.fn(),
+    isActive: vi.fn().mockReturnValue(true),
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    initializeTools(mockSessionManager);
+    mockResolvePage.mockReturnValue({
+      page_id: 'page-1',
+      page: {},
+      cdp: mockCdp,
+      created_at: new Date(),
+    });
+  });
+
+  it('should capture viewport screenshot with default options', async () => {
+    mockCaptureScreenshot.mockResolvedValue({
+      type: 'image',
+      data: 'base64data',
+      mimeType: 'image/png',
+      sizeBytes: 1024,
+    });
+
+    const result = await takeScreenshot({});
+
+    expect(result.type).toBe('image');
+    expect(mockCaptureScreenshot).toHaveBeenCalledWith(mockCdp, {
+      format: 'png',
+      quality: undefined,
+      clip: undefined,
+      captureBeyondViewport: false,
+    });
+  });
+
+  it('should capture full page screenshot', async () => {
+    mockCaptureScreenshot.mockResolvedValue({
+      type: 'image',
+      data: 'base64data',
+      mimeType: 'image/png',
+      sizeBytes: 1024,
+    });
+
+    await takeScreenshot({ fullPage: true });
+
+    expect(mockCaptureScreenshot).toHaveBeenCalledWith(
+      mockCdp,
+      expect.objectContaining({ captureBeyondViewport: true })
+    );
+  });
+
+  it('should capture JPEG with quality', async () => {
+    mockCaptureScreenshot.mockResolvedValue({
+      type: 'image',
+      data: 'base64data',
+      mimeType: 'image/jpeg',
+      sizeBytes: 512,
+    });
+
+    await takeScreenshot({ format: 'jpeg', quality: 60 });
+
+    expect(mockCaptureScreenshot).toHaveBeenCalledWith(
+      mockCdp,
+      expect.objectContaining({ format: 'jpeg', quality: 60 })
+    );
+  });
+
+  it('should capture element screenshot when eid is provided', async () => {
+    const mockNode = { backend_node_id: 42, kind: 'button', label: 'Submit' };
+    const mockSnapshot = { snapshot_id: 'snap-1', nodes: [mockNode] };
+    mockStoreGetByPageId.mockReturnValue(mockSnapshot);
+
+    const mockRegistry = {
+      getByEid: vi.fn().mockReturnValue({ ref: { backend_node_id: 42 } }),
+      isStale: vi.fn().mockReturnValue(false),
+    };
+    mockGetStateManager.mockReturnValue({
+      getElementRegistry: () => mockRegistry,
+    });
+
+    const clip = { x: 10, y: 20, width: 100, height: 50, scale: 1 };
+    mockGetElementBoundingBox.mockResolvedValue(clip);
+
+    mockCaptureScreenshot.mockResolvedValue({
+      type: 'image',
+      data: 'base64data',
+      mimeType: 'image/png',
+      sizeBytes: 512,
+    });
+
+    await takeScreenshot({ eid: 'btn-submit' });
+
+    expect(mockGetElementBoundingBox).toHaveBeenCalledWith(mockCdp, 42);
+    expect(mockCaptureScreenshot).toHaveBeenCalledWith(
+      mockCdp,
+      expect.objectContaining({ clip })
+    );
+  });
+
+  it('should reject when both eid and fullPage are provided', async () => {
+    await expect(takeScreenshot({ eid: 'btn-1', fullPage: true })).rejects.toThrow(
+      "Cannot use both 'eid' and 'fullPage'"
+    );
+  });
+
+  it('should return FileResult for large screenshots', async () => {
+    mockCaptureScreenshot.mockResolvedValue({
+      type: 'file',
+      path: '/tmp/screenshot-abc123.png',
+      mimeType: 'image/png',
+      sizeBytes: 3 * 1024 * 1024,
+    });
+
+    const result = await takeScreenshot({});
+
+    expect(result.type).toBe('file');
+    if (result.type === 'file') {
+      expect(result.path).toContain('screenshot-');
+    }
+  });
+
+  it('should throw when page not found', async () => {
+    mockResolvePage.mockReturnValue(null);
+
+    await expect(takeScreenshot({ page_id: 'nonexistent' })).rejects.toThrow('Page not found');
+  });
+
+  it('should throw when eid provided but no snapshot exists', async () => {
+    mockStoreGetByPageId.mockReturnValue(null);
+
+    await expect(takeScreenshot({ eid: 'btn-1' })).rejects.toThrow();
+  });
+
+  it('should resolve page_id correctly', async () => {
+    mockCaptureScreenshot.mockResolvedValue({
+      type: 'image',
+      data: 'abc',
+      mimeType: 'image/png',
+      sizeBytes: 3,
+    });
+
+    await takeScreenshot({ page_id: 'page-1' });
+
+    expect(mockResolvePage).toHaveBeenCalledWith('page-1');
+    expect(mockTouchPage).toHaveBeenCalledWith('page-1');
+  });
+});

--- a/tests/unit/tools/take-screenshot.test.ts
+++ b/tests/unit/tools/take-screenshot.test.ts
@@ -210,10 +210,7 @@ describe('takeScreenshot', () => {
     await takeScreenshot({ eid: 'btn-submit' });
 
     expect(mockGetElementBoundingBox).toHaveBeenCalledWith(mockCdp, 42);
-    expect(mockCaptureScreenshot).toHaveBeenCalledWith(
-      mockCdp,
-      expect.objectContaining({ clip })
-    );
+    expect(mockCaptureScreenshot).toHaveBeenCalledWith(mockCdp, expect.objectContaining({ clip }));
   });
 
   it('should reject when both eid and fullPage are provided', async () => {

--- a/tests/unit/tools/tool-result-types.test.ts
+++ b/tests/unit/tools/tool-result-types.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Tool Result Types Tests
+ */
+import { describe, it, expect } from 'vitest';
+import {
+  isImageResult,
+  isFileResult,
+  type ImageResult,
+  type FileResult,
+} from '../../../src/tools/tool-result.types.js';
+
+describe('isImageResult', () => {
+  it('should return true for valid ImageResult', () => {
+    const result: ImageResult = {
+      type: 'image',
+      data: 'base64data',
+      mimeType: 'image/png',
+      sizeBytes: 1024,
+    };
+    expect(isImageResult(result)).toBe(true);
+  });
+
+  it('should return false for FileResult', () => {
+    const result: FileResult = {
+      type: 'file',
+      path: '/tmp/test.png',
+      mimeType: 'image/png',
+      sizeBytes: 1024,
+    };
+    expect(isImageResult(result)).toBe(false);
+  });
+
+  it('should return false for plain string', () => {
+    expect(isImageResult('<xml>text</xml>')).toBe(false);
+  });
+
+  it('should return false for null', () => {
+    expect(isImageResult(null)).toBe(false);
+  });
+
+  it('should return false for undefined', () => {
+    expect(isImageResult(undefined)).toBe(false);
+  });
+
+  it('should return false for objects missing required fields', () => {
+    expect(isImageResult({ type: 'image' })).toBe(false);
+    expect(isImageResult({ type: 'image', data: 'abc' })).toBe(false);
+  });
+});
+
+describe('isFileResult', () => {
+  it('should return true for valid FileResult', () => {
+    const result: FileResult = {
+      type: 'file',
+      path: '/tmp/screenshot.png',
+      mimeType: 'image/png',
+      sizeBytes: 2048,
+    };
+    expect(isFileResult(result)).toBe(true);
+  });
+
+  it('should return false for ImageResult', () => {
+    const result: ImageResult = {
+      type: 'image',
+      data: 'base64',
+      mimeType: 'image/jpeg',
+      sizeBytes: 512,
+    };
+    expect(isFileResult(result)).toBe(false);
+  });
+
+  it('should return false for plain string', () => {
+    expect(isFileResult('some text')).toBe(false);
+  });
+
+  it('should return false for null', () => {
+    expect(isFileResult(null)).toBe(false);
+  });
+
+  it('should return false for objects missing required fields', () => {
+    expect(isFileResult({ type: 'file' })).toBe(false);
+    expect(isFileResult({ type: 'file', path: '/tmp' })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `take_screenshot` MCP tool (tool #20) supporting viewport, full-page, and element screenshot modes with PNG/JPEG formats
- Return inline `ImageContent` for small screenshots (<2MB) or save to temp file with session cleanup for large ones (>=2MB)
- Clean architecture: `ToolResult` discriminated union types, `screenshot-capture` service, `temp-file` utility, and MCP server `ImageContent` integration

## New Files
- `src/screenshot/screenshot-capture.ts` — CDP screenshot capture + element bounding box
- `src/tools/tool-result.types.ts` — `ImageResult`/`FileResult` types with type guards
- `src/lib/temp-file.ts` — Temp file writer with session cleanup

## Modified Files
- `src/tools/browser-tools.ts` — `takeScreenshot` handler with `ensureCdpSession` health check
- `src/server/mcp-server.ts` — `ImageContent` and file path result handling
- `src/tools/tool-schemas.ts` — `TakeScreenshotInputSchema` + `TakeScreenshotOutputSchema`
- `src/tools/index.ts` — Barrel exports
- `src/index.ts` — Tool registration in Observation section
- `CLAUDE.md` — Updated tool count, categories, and directory structure

## Test Plan
- [ ] 15 unit tests for `screenshot-capture` (viewport, JPEG, element clip, rotated element bounding box)
- [ ] 11 unit tests for `temp-file` (write, base64 size, cleanup on session close)
- [ ] 9 unit tests for `takeScreenshot` handler (defaults, fullPage, eid, format, error cases)
- [ ] 11 unit tests for `ToolResult` type guards
- [ ] All 1598 tests pass, type-check clean, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)