### PR TITLE
fix: address critical issues from take_screenshot PR review

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {
   isSessionManagerInitialized,
 } from './server/server-config.js';
 import { getLogger } from './shared/services/logging.service.js';
+import { cleanupTempFiles } from './lib/temp-file.js';
 
 const logger = getLogger();
 import {
@@ -376,6 +377,7 @@ async function main(): Promise<void> {
       console.error(`Shutting down... (${signal})`);
       void (async () => {
         try {
+          await cleanupTempFiles();
           // Shutdown browser session first (only if initialized)
           if (isSessionManagerInitialized()) {
             const session = getSessionManager();

--- a/src/lib/temp-file.ts
+++ b/src/lib/temp-file.ts
@@ -49,8 +49,10 @@ export function computeBase64ByteSize(base64: string): number {
  */
 export async function cleanupTempFiles(): Promise<void> {
   const deletions = [...trackedFiles].map((filepath) =>
-    unlink(filepath).catch(() => {
-      /* already deleted or inaccessible — ignore */
+    unlink(filepath).catch((err: NodeJS.ErrnoException) => {
+      if (err.code !== 'ENOENT') {
+        console.warn(`[cleanup] Failed to delete temp file ${filepath}: ${err.message}`);
+      }
     })
   );
   await Promise.all(deletions);

--- a/src/screenshot/screenshot-capture.ts
+++ b/src/screenshot/screenshot-capture.ts
@@ -53,10 +53,19 @@ export async function captureScreenshot(
     format,
     quality: format === 'jpeg' ? (options.quality ?? 80) : undefined,
     optimizeForSpeed: options.optimizeForSpeed ?? true,
-    captureBeyondViewport: options.captureBeyondViewport ?? false,
   };
 
-  if (options.clip) {
+  if (options.captureBeyondViewport) {
+    const metrics = await cdp.send('Page.getLayoutMetrics', undefined);
+    params.clip = {
+      x: 0,
+      y: 0,
+      width: metrics.cssContentSize.width,
+      height: metrics.cssContentSize.height,
+      scale: 1,
+    };
+    params.captureBeyondViewport = true;
+  } else if (options.clip) {
     params.clip = options.clip;
   }
 

--- a/src/tools/tool-schemas.ts
+++ b/src/tools/tool-schemas.ts
@@ -768,14 +768,14 @@ const TakeScreenshotInputSchemaBase = z.object({
   /** Capture full page beyond viewport. Cannot combine with eid. */
   fullPage: z
     .boolean()
-    .default(false)
     .optional()
+    .default(false)
     .describe('Capture full page height beyond the viewport. Cannot be combined with eid.'),
   /** Image format (default: png) */
   format: z
     .enum(['png', 'jpeg'])
-    .default('png')
     .optional()
+    .default('png')
     .describe("Image format: 'png' (lossless, default) or 'jpeg' (lossy with quality control)."),
   /** JPEG quality 0-100 (ignored for PNG) */
   quality: z

--- a/tests/unit/lib/temp-file.test.ts
+++ b/tests/unit/lib/temp-file.test.ts
@@ -112,7 +112,9 @@ describe('cleanupTempFiles', () => {
     await writeTempFile('dGVzdA==', 'png');
 
     // Should not throw and should not warn
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { /* noop */ });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {
+      /* noop */
+    });
     await expect(cleanupTempFiles()).resolves.toBeUndefined();
     expect(warnSpy).not.toHaveBeenCalled();
     warnSpy.mockRestore();
@@ -126,7 +128,9 @@ describe('cleanupTempFiles', () => {
 
     await writeTempFile('dGVzdA==', 'png');
 
-    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { /* noop */ });
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {
+      /* noop */
+    });
     await expect(cleanupTempFiles()).resolves.toBeUndefined();
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('EACCES'));
     warnSpy.mockRestore();

--- a/tests/unit/lib/temp-file.test.ts
+++ b/tests/unit/lib/temp-file.test.ts
@@ -103,12 +103,32 @@ describe('cleanupTempFiles', () => {
     expect(unlink).not.toHaveBeenCalled();
   });
 
-  it('should silently ignore already-deleted files', async () => {
-    vi.mocked(unlink).mockRejectedValue(new Error('ENOENT'));
+  it('should silently ignore already-deleted files (ENOENT)', async () => {
+    const enoentError = Object.assign(new Error('ENOENT: no such file or directory'), {
+      code: 'ENOENT',
+    });
+    vi.mocked(unlink).mockRejectedValue(enoentError);
 
     await writeTempFile('dGVzdA==', 'png');
 
-    // Should not throw
+    // Should not throw and should not warn
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { /* noop */ });
     await expect(cleanupTempFiles()).resolves.toBeUndefined();
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it('should log warning for non-ENOENT errors (e.g. EACCES)', async () => {
+    const eaccesError = Object.assign(new Error('EACCES: permission denied'), {
+      code: 'EACCES',
+    });
+    vi.mocked(unlink).mockRejectedValue(eaccesError);
+
+    await writeTempFile('dGVzdA==', 'png');
+
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => { /* noop */ });
+    await expect(cleanupTempFiles()).resolves.toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('EACCES'));
+    warnSpy.mockRestore();
   });
 });

--- a/tests/unit/screenshot/screenshot-capture.test.ts
+++ b/tests/unit/screenshot/screenshot-capture.test.ts
@@ -145,10 +145,13 @@ describe('captureScreenshot', () => {
     await captureScreenshot(cdp, { captureBeyondViewport: true });
 
     expect(cdp.send).toHaveBeenCalledWith('Page.getLayoutMetrics', undefined);
-    expect(cdp.send).toHaveBeenCalledWith('Page.captureScreenshot', expect.objectContaining({
-      captureBeyondViewport: true,
-      clip: { x: 0, y: 0, width: 1280, height: 5000, scale: 1 },
-    }));
+    expect(cdp.send).toHaveBeenCalledWith(
+      'Page.captureScreenshot',
+      expect.objectContaining({
+        captureBeyondViewport: true,
+        clip: { x: 0, y: 0, width: 1280, height: 5000, scale: 1 },
+      })
+    );
   });
 
   it('should not call Page.getLayoutMetrics for viewport screenshots', async () => {

--- a/tests/unit/screenshot/screenshot-capture.test.ts
+++ b/tests/unit/screenshot/screenshot-capture.test.ts
@@ -72,7 +72,6 @@ describe('captureScreenshot', () => {
       format: 'png',
       quality: undefined,
       optimizeForSpeed: true,
-      captureBeyondViewport: false,
     });
   });
 
@@ -86,7 +85,6 @@ describe('captureScreenshot', () => {
       format: 'jpeg',
       quality: 75,
       optimizeForSpeed: true,
-      captureBeyondViewport: false,
     });
   });
 
@@ -134,16 +132,38 @@ describe('captureScreenshot', () => {
     );
   });
 
-  it('should set captureBeyondViewport for full page screenshots', async () => {
-    vi.mocked(cdp.send).mockResolvedValue({ data: 'abc' });
+  it('should call Page.getLayoutMetrics and set clip for full page screenshots', async () => {
+    vi.mocked(cdp.send)
+      .mockResolvedValueOnce({
+        cssContentSize: { width: 1280, height: 5000 },
+        cssLayoutViewport: { clientWidth: 1280, clientHeight: 720 },
+        cssVisualViewport: { clientWidth: 1280, clientHeight: 720 },
+      })
+      .mockResolvedValueOnce({ data: 'abc' });
     vi.mocked(computeBase64ByteSize).mockReturnValue(3);
 
     await captureScreenshot(cdp, { captureBeyondViewport: true });
 
-    expect(cdp.send).toHaveBeenCalledWith(
-      'Page.captureScreenshot',
-      expect.objectContaining({ captureBeyondViewport: true })
-    );
+    expect(cdp.send).toHaveBeenCalledWith('Page.getLayoutMetrics', undefined);
+    expect(cdp.send).toHaveBeenCalledWith('Page.captureScreenshot', expect.objectContaining({
+      captureBeyondViewport: true,
+      clip: { x: 0, y: 0, width: 1280, height: 5000, scale: 1 },
+    }));
+  });
+
+  it('should not call Page.getLayoutMetrics for viewport screenshots', async () => {
+    vi.mocked(cdp.send).mockResolvedValue({ data: 'abc' });
+    vi.mocked(computeBase64ByteSize).mockReturnValue(3);
+
+    await captureScreenshot(cdp);
+
+    expect(cdp.send).not.toHaveBeenCalledWith('Page.getLayoutMetrics', undefined);
+    expect(cdp.send).toHaveBeenCalledTimes(1);
+    expect(cdp.send).toHaveBeenCalledWith('Page.captureScreenshot', {
+      format: 'png',
+      quality: undefined,
+      optimizeForSpeed: true,
+    });
   });
 
   it('should respect optimizeForSpeed=false', async () => {

--- a/tests/unit/tools/take-screenshot.test.ts
+++ b/tests/unit/tools/take-screenshot.test.ts
@@ -107,10 +107,29 @@ vi.mock('../../../src/lib/temp-file.js', () => ({
 }));
 
 import { initializeTools, takeScreenshot } from '../../../src/tools/browser-tools.js';
+import { TakeScreenshotInputSchema } from '../../../src/tools/tool-schemas.js';
 
 // ============================================================================
 // Tests
 // ============================================================================
+
+describe('TakeScreenshotInput schema', () => {
+  it('should default fullPage to false when omitted', () => {
+    const result = TakeScreenshotInputSchema.parse({});
+    expect(result).toHaveProperty('fullPage', false);
+  });
+
+  it('should default format to png when omitted', () => {
+    const result = TakeScreenshotInputSchema.parse({});
+    expect(result.format).toBe('png');
+  });
+
+  it('should preserve explicit values', () => {
+    const result = TakeScreenshotInputSchema.parse({ fullPage: true, format: 'jpeg' });
+    expect(result.fullPage).toBe(true);
+    expect(result.format).toBe('jpeg');
+  });
+});
 
 describe('takeScreenshot', () => {
   const mockCdp = {


### PR DESCRIPTION
## Summary
- **Zod schema ordering**: Swap `.default().optional()` to `.optional().default()` for `fullPage` and `format` fields so Zod actually applies defaults after parsing
- **Full-page screenshots**: Use `Page.getLayoutMetrics` to get document dimensions and pass as `clip`, instead of relying solely on the `captureBeyondViewport` flag
- **Error handling in cleanup**: Only suppress `ENOENT` in `cleanupTempFiles`, log other errors via `console.warn`
- **Shutdown path**: Add `cleanupTempFiles()` call in the shutdown handler before browser session shutdown

## Test plan
- [x] Added schema parse tests verifying defaults are applied when fields omitted
- [x] Added test for `Page.getLayoutMetrics` call and clip params on full-page screenshots
- [x] Added test verifying `Page.getLayoutMetrics` is NOT called for viewport screenshots
- [x] Updated ENOENT test to use proper error object with `code` property
- [x] Added test for non-ENOENT errors (EACCES) logging via `console.warn`
- [x] All 1625 tests pass, type-check clean, lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)