### PR TITLE
fix: portal-rendered overlay content missing from snapshots

### DIFF
--- a/src/snapshot/snapshot-compiler.ts
+++ b/src/snapshot/snapshot-compiler.ts
@@ -687,8 +687,8 @@ export class SnapshotCompiler {
       }
     }
 
-    // Limit nodes (now respects DOM order)
-    const limitedNodes = nodesToProcess.slice(0, this.options.max_nodes);
+    // Limit nodes (now respects DOM order and preserves overlay content)
+    const limitedNodes = sliceWithOverlayPriority(nodesToProcess, this.options.max_nodes);
 
     // Phase 3: Layout extraction (batched)
     let layoutResult: LayoutExtractionResult | undefined;
@@ -1063,6 +1063,63 @@ export class SnapshotCompiler {
       return true; // Keep the node
     });
   }
+}
+
+/**
+ * Slice nodes to max_nodes budget while preserving high z-index overlay content.
+ *
+ * Portal-rendered content (dropdowns, popovers, modals) appears at the end of
+ * DOM order. On heavy pages, a naive slice truncates it.
+ *
+ * Strategy:
+ * 1. Partition nodes into overlay (z-index > threshold) and main
+ * 2. Take all overlay nodes (up to 30% of budget)
+ * 3. Fill remaining budget with main nodes (DOM order)
+ * 4. Re-sort by original DOM order
+ */
+export function sliceWithOverlayPriority(nodes: RawNodeData[], maxNodes: number): RawNodeData[] {
+  if (nodes.length <= maxNodes) {
+    return nodes;
+  }
+
+  const OVERLAY_Z_THRESHOLD = 100;
+  const MAX_OVERLAY_RATIO = 0.3;
+
+  const overlayNodes: RawNodeData[] = [];
+  const mainNodes: RawNodeData[] = [];
+
+  for (const node of nodes) {
+    const zIndex = node.layout?.zIndex;
+    if (zIndex !== undefined && zIndex > OVERLAY_Z_THRESHOLD) {
+      overlayNodes.push(node);
+    } else {
+      mainNodes.push(node);
+    }
+  }
+
+  // No overlay content → simple slice
+  if (overlayNodes.length === 0) {
+    return nodes.slice(0, maxNodes);
+  }
+
+  // Reserve budget for overlay (capped at 30% of total)
+  const maxOverlay = Math.min(overlayNodes.length, Math.floor(maxNodes * MAX_OVERLAY_RATIO));
+  const overlaySlice = overlayNodes.slice(0, maxOverlay);
+
+  // Fill remaining budget with main content
+  const mainBudget = maxNodes - overlaySlice.length;
+  const mainSlice = mainNodes.slice(0, mainBudget);
+
+  // Merge and re-sort by original DOM order
+  const merged = [...mainSlice, ...overlaySlice];
+  const indexMap = new Map(nodes.map((n, i) => [n.backendNodeId, i]));
+  merged.sort((a, b) => {
+    const ia = indexMap.get(a.backendNodeId) ?? Infinity;
+    const ib = indexMap.get(b.backendNodeId) ?? Infinity;
+    return ia - ib;
+  });
+
+  return merged;
 }
 
 /**

--- a/src/state/actionables-filter.ts
+++ b/src/state/actionables-filter.ts
@@ -7,6 +7,7 @@
 
 import type { BaseSnapshot, ReadableNode, NodeKind } from '../snapshot/snapshot.types.js';
 import type { ScoringContext } from './types.js';
+import { getNodeLayer, INCLUSIVE_OVERLAY_LAYERS } from './node-layer.js';
 
 // Interactive element kinds
 const INTERACTIVE_KINDS: NodeKind[] = [
@@ -57,6 +58,8 @@ export function selectActionables(
   maxCount: number,
   context?: ScoringContext
 ): ReadableNode[] {
+  const skipLayerFilter = INCLUSIVE_OVERLAY_LAYERS.has(activeLayer);
+
   // Filter to candidates
   const candidates = snapshot.nodes.filter((node) => {
     // Must be interactive
@@ -69,10 +72,12 @@ export function selectActionables(
       return false;
     }
 
-    // Must be in active layer
-    const nodeLayer = getNodeLayer(node);
-    if (nodeLayer !== activeLayer) {
-      return false;
+    // Must be in active layer (skip for inclusive overlays like popover/drawer)
+    if (!skipLayerFilter) {
+      const nodeLayer = getNodeLayer(node, activeLayer);
+      if (nodeLayer !== activeLayer) {
+        return false;
+      }
     }
 
     return true;
@@ -171,34 +176,4 @@ export function scoreActionable(node: ReadableNode, context?: ScoringContext): n
 
   // Cap at 1.0
   return Math.min(score, 1.0);
-}
-
-// ============================================================================
-// Layer Determination
-// ============================================================================
-
-/**
- * Determine which layer a node belongs to.
- * Simplified: use region as proxy.
- *
- * Modal elements are in 'dialog' region.
- * Everything else is in 'main'.
- *
- * TODO: Make this more sophisticated by checking node ancestry
- * and matching against detected layer root EIDs.
- *
- * @param node - Node to check
- * @returns Layer name
- */
-function getNodeLayer(node: ReadableNode): string {
-  const region = node.where.region ?? 'unknown';
-
-  // Dialog region maps to modal layer
-  if (region === 'dialog') {
-    return 'modal';
-  }
-
-  // Everything else maps to main layer
-  // TODO: Add drawer and popover detection based on ancestry
-  return 'main';
 }

--- a/src/state/locator-generator.ts
+++ b/src/state/locator-generator.ts
@@ -9,6 +9,7 @@
 
 import type { ReadableNode } from '../snapshot/snapshot.types.js';
 import type { LocatorInfo } from './types.js';
+import { getNodeLayer } from './node-layer.js';
 
 // ============================================================================
 // Layer Scope Configuration
@@ -67,17 +68,6 @@ export function generateLocator(node: ReadableNode, layer?: string): LocatorInfo
     preferred: { ax: axLocator },
     fallback: cssLocator ? { css: cssLocator } : undefined,
   };
-}
-
-/**
- * Determine which layer a node belongs to from its region.
- *
- * @param node - Node to check
- * @returns Layer name
- */
-function getNodeLayer(node: ReadableNode): string {
-  const region = node.where.region ?? 'unknown';
-  return region === 'dialog' ? 'modal' : 'main';
 }
 
 // ============================================================================

--- a/src/state/node-layer.ts
+++ b/src/state/node-layer.ts
@@ -1,0 +1,49 @@
+/**
+ * Node Layer Assignment
+ *
+ * Determines which UI layer a node belongs to.
+ * Used by actionables filter, state manager, and locator generator.
+ */
+
+import type { ReadableNode } from '../snapshot/snapshot.types.js';
+
+/**
+ * Z-index threshold for assigning nodes to overlay layers.
+ * Nodes with z-index above this are considered part of the active overlay.
+ * Deliberately low — the layer detector already validated the overlay exists;
+ * we just need to distinguish overlay content from background content.
+ */
+const OVERLAY_Z_INDEX_THRESHOLD = 1;
+
+/**
+ * Layer types where content coexists with main (unlike modal which blocks).
+ * Used for z-index-based node assignment and to skip layer filtering.
+ */
+export const INCLUSIVE_OVERLAY_LAYERS = new Set(['popover', 'drawer']);
+
+/**
+ * Determine which layer a node belongs to.
+ *
+ * @param node - ReadableNode to classify
+ * @param activeLayer - Currently active layer from layer detector (optional).
+ *   When provided, enables z-index-based assignment for popover/drawer layers.
+ * @returns Layer name: 'main', 'modal', 'popover', or 'drawer'
+ */
+export function getNodeLayer(node: ReadableNode, activeLayer?: string): string {
+  const region = node.where.region ?? 'unknown';
+
+  // Dialog region always maps to modal layer
+  if (region === 'dialog') {
+    return 'modal';
+  }
+
+  // When active layer is popover/drawer, use z-index to determine membership
+  if (activeLayer && INCLUSIVE_OVERLAY_LAYERS.has(activeLayer)) {
+    const zIndex = node.layout.zIndex;
+    if (zIndex !== undefined && zIndex > OVERLAY_Z_INDEX_THRESHOLD) {
+      return activeLayer;
+    }
+  }
+
+  return 'main';
+}

--- a/src/state/state-manager.ts
+++ b/src/state/state-manager.ts
@@ -28,6 +28,7 @@ import { computeEid, resolveEidCollision } from './element-identity.js';
 import { detectLayers } from './layer-detector.js';
 import { computeDiff } from './diff-engine.js';
 import { selectActionables, isInteractiveKind } from './actionables-filter.js';
+import { getNodeLayer, INCLUSIVE_OVERLAY_LAYERS } from './node-layer.js';
 import { extractAtoms } from './atoms-extractor.js';
 import { linkObservationsToSnapshot } from '../observation/index.js';
 import { generateLocator } from './locator-generator.js';
@@ -282,8 +283,12 @@ export class StateManager {
     );
 
     // Count total actionables in active layer
+    const skipLayerFilter = INCLUSIVE_OVERLAY_LAYERS.has(layerResult.active);
     const totalInLayer = snapshot.nodes.filter(
-      (n) => isInteractiveKind(n.kind) && n.state?.visible && getNodeLayer(n) === layerResult.active
+      (n) =>
+        isInteractiveKind(n.kind) &&
+        n.state?.visible &&
+        (skipLayerFilter || getNodeLayer(n, layerResult.active) === layerResult.active)
     ).length;
 
     const counts = {
@@ -427,6 +432,7 @@ export class StateManager {
     context: ScoringContext
   ): ReadableNode[] {
     const maxCount = this.context.config.maxActionables;
+    const skipLayerFilter = INCLUSIVE_OVERLAY_LAYERS.has(activeLayer);
 
     // Find focused element first
     const focusedNode = snapshot.nodes.find(
@@ -434,7 +440,7 @@ export class StateManager {
         n.state?.focused &&
         isInteractiveKind(n.kind) &&
         n.state?.visible &&
-        getNodeLayer(n) === activeLayer
+        (skipLayerFilter || getNodeLayer(n, activeLayer) === activeLayer)
     );
 
     // Find modal close/cancel affordances (high priority in modal layer)
@@ -442,7 +448,7 @@ export class StateManager {
     if (activeLayer === 'modal') {
       for (const node of snapshot.nodes) {
         if (!isInteractiveKind(node.kind) || !node.state?.visible) continue;
-        if (getNodeLayer(node) !== activeLayer) continue;
+        if (getNodeLayer(node, activeLayer) !== activeLayer) continue;
 
         const label = node.label.toLowerCase();
         const isCloseAffordance =
@@ -582,7 +588,7 @@ export class StateManager {
         ref,
         loc,
         ctx: {
-          layer: getNodeLayer(node),
+          layer: getNodeLayer(node, activeLayer),
           region: node.where.region ?? 'unknown',
         },
       };
@@ -786,9 +792,4 @@ function computeLayerHash(stack: string[]): string {
 
 function hash(input: string): string {
   return createHash('sha256').update(input).digest('hex').substring(0, 12);
-}
-
-function getNodeLayer(node: ReadableNode): string {
-  const region = node.where.region ?? 'unknown';
-  return region === 'dialog' ? 'modal' : 'main';
 }

--- a/tests/unit/snapshot/snapshot-compiler-overlay-priority.test.ts
+++ b/tests/unit/snapshot/snapshot-compiler-overlay-priority.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Snapshot Compiler — Overlay Priority Tests
+ *
+ * Verifies that sliceWithOverlayPriority preserves high z-index
+ * overlay content when max_nodes would otherwise truncate it.
+ */
+import { describe, it, expect } from 'vitest';
+import { sliceWithOverlayPriority } from '../../../src/snapshot/snapshot-compiler.js';
+import type { RawNodeData } from '../../../src/snapshot/extractors/types.js';
+
+// Minimal RawNodeData-like objects for testing
+function makeRawNode(backendNodeId: number, zIndex?: number): RawNodeData {
+  return {
+    backendNodeId,
+    layout: zIndex !== undefined ? ({ zIndex } as RawNodeData['layout']) : undefined,
+  };
+}
+
+describe('sliceWithOverlayPriority', () => {
+  it('should return all nodes when under budget', () => {
+    const nodes = [makeRawNode(1), makeRawNode(2), makeRawNode(3)];
+    const result = sliceWithOverlayPriority(nodes, 10);
+    expect(result).toHaveLength(3);
+  });
+
+  it('should simple-slice when no overlay content exists', () => {
+    const nodes = Array.from({ length: 10 }, (_, i) => makeRawNode(i));
+    const result = sliceWithOverlayPriority(nodes, 5);
+    expect(result).toHaveLength(5);
+    expect(result.map((n) => n.backendNodeId)).toEqual([0, 1, 2, 3, 4]);
+  });
+
+  it('should preserve high z-index overlay nodes even when they would be truncated', () => {
+    // 20 main nodes + 3 overlay nodes at end (portal-rendered)
+    const nodes = [
+      ...Array.from({ length: 20 }, (_, i) => makeRawNode(i)),
+      makeRawNode(100, 1300),
+      makeRawNode(101, 1300),
+      makeRawNode(102, 1300),
+    ];
+    // Budget of 10: 30% = 3 overlay slots, all 3 overlay nodes fit
+    const result = sliceWithOverlayPriority(nodes, 10);
+    expect(result).toHaveLength(10);
+    // All overlay nodes should be present
+    const overlayIds = result.filter((n) => n.backendNodeId >= 100).map((n) => n.backendNodeId);
+    expect(overlayIds).toContain(100);
+    expect(overlayIds).toContain(101);
+    expect(overlayIds).toContain(102);
+    // Remaining 7 slots filled with main content
+    const mainIds = result.filter((n) => n.backendNodeId < 100);
+    expect(mainIds).toHaveLength(7);
+  });
+
+  it('should cap overlay nodes at 30% of budget', () => {
+    // 50 main + 20 overlay, budget=10 → max 3 overlay (30% of 10)
+    const nodes = [
+      ...Array.from({ length: 50 }, (_, i) => makeRawNode(i)),
+      ...Array.from({ length: 20 }, (_, i) => makeRawNode(100 + i, 500)),
+    ];
+    const result = sliceWithOverlayPriority(nodes, 10);
+    expect(result).toHaveLength(10);
+    const overlayCount = result.filter((n) => n.backendNodeId >= 100).length;
+    expect(overlayCount).toBe(3); // 30% of 10
+  });
+
+  it('should maintain DOM order in output', () => {
+    const nodes = [
+      makeRawNode(1),
+      makeRawNode(2),
+      makeRawNode(3),
+      makeRawNode(50, 1300), // overlay in middle
+      makeRawNode(4),
+      makeRawNode(5),
+      makeRawNode(60, 1300), // overlay at end
+    ];
+    const result = sliceWithOverlayPriority(nodes, 5);
+    // Should preserve relative order
+    const ids = result.map((n) => n.backendNodeId);
+    for (let i = 1; i < ids.length; i++) {
+      const prevIndex = nodes.findIndex((n) => n.backendNodeId === ids[i - 1]);
+      const currIndex = nodes.findIndex((n) => n.backendNodeId === ids[i]);
+      expect(prevIndex).toBeLessThan(currIndex);
+    }
+  });
+
+  it('should treat z-index at threshold (100) as main content', () => {
+    const nodes = [
+      ...Array.from({ length: 8 }, (_, i) => makeRawNode(i)),
+      makeRawNode(10, 100), // exactly at threshold, should be treated as main
+      makeRawNode(11, 101), // above threshold, should be treated as overlay
+    ];
+    const result = sliceWithOverlayPriority(nodes, 9);
+    expect(result).toHaveLength(9);
+    // Node with z-index 101 should be preserved as overlay
+    expect(result.some((n) => n.backendNodeId === 11)).toBe(true);
+    // Node with z-index 100 is main content, may or may not be included depending on budget
+    // With 1 overlay (30% of 9 = 2 max), mainBudget = 8, and we have 9 main nodes
+    // So node 10 (z=100) might be included (it's the 9th main node, budget is 8)
+  });
+
+  it('should treat nodes without layout as main content', () => {
+    // 5 main nodes (no layout) + 1 overlay, budget=4 → 30% of 4 = 1 overlay slot
+    const nodes: RawNodeData[] = [
+      makeRawNode(1), // no layout
+      { backendNodeId: 2 }, // no layout at all
+      makeRawNode(3), // no layout
+      makeRawNode(4), // no layout
+      makeRawNode(5), // no layout
+      makeRawNode(6, 1300), // overlay
+    ];
+    const result = sliceWithOverlayPriority(nodes, 4);
+    expect(result).toHaveLength(4);
+    // Overlay node should be included (1 fits in 30% of 4)
+    expect(result.some((n) => n.backendNodeId === 6)).toBe(true);
+    // Remaining 3 should be main content
+    const mainNodes = result.filter((n) => n.backendNodeId !== 6);
+    expect(mainNodes).toHaveLength(3);
+  });
+});

--- a/tests/unit/state/actionables-filter.test.ts
+++ b/tests/unit/state/actionables-filter.test.ts
@@ -118,4 +118,122 @@ describe('selectActionables', () => {
       expect(result.length).toBe(0);
     });
   });
+
+  describe('layer filtering', () => {
+    it('should include all visible elements when activeLayer is popover', () => {
+      const snapshot = createTestSnapshot([
+        {
+          kind: 'button',
+          label: 'Main Submit',
+          where: { region: 'main' },
+          layout: {
+            bbox: { x: 0, y: 0, w: 100, h: 40 },
+            display: 'block',
+            screen_zone: 'top-center' as const,
+          },
+          state: { visible: true, enabled: true },
+        },
+        {
+          kind: 'menuitem',
+          label: 'Popover Option 1',
+          where: { region: 'main' },
+          layout: {
+            bbox: { x: 0, y: 50, w: 100, h: 40 },
+            display: 'block',
+            screen_zone: 'top-center' as const,
+            zIndex: 100,
+          },
+          state: { visible: true, enabled: true },
+        },
+        {
+          kind: 'menuitem',
+          label: 'Popover Option 2',
+          where: { region: 'main' },
+          layout: {
+            bbox: { x: 0, y: 100, w: 100, h: 40 },
+            display: 'block',
+            screen_zone: 'top-center' as const,
+            zIndex: 100,
+          },
+          state: { visible: true, enabled: true },
+        },
+      ]);
+
+      const result = selectActionables(snapshot, 'popover', 100);
+
+      // Both main content and popover elements should be included
+      expect(result.length).toBe(3);
+      expect(result.some((n) => n.label === 'Main Submit')).toBe(true);
+      expect(result.some((n) => n.label === 'Popover Option 1')).toBe(true);
+      expect(result.some((n) => n.label === 'Popover Option 2')).toBe(true);
+    });
+
+    it('should only include modal elements when activeLayer is modal', () => {
+      const snapshot = createTestSnapshot([
+        {
+          kind: 'button',
+          label: 'Main Submit',
+          where: { region: 'main' },
+          layout: {
+            bbox: { x: 0, y: 0, w: 100, h: 40 },
+            display: 'block',
+            screen_zone: 'top-center' as const,
+          },
+          state: { visible: true, enabled: true },
+        },
+        {
+          kind: 'button',
+          label: 'Dialog Confirm',
+          where: { region: 'dialog' },
+          layout: {
+            bbox: { x: 0, y: 50, w: 100, h: 40 },
+            display: 'block',
+            screen_zone: 'top-center' as const,
+          },
+          state: { visible: true, enabled: true },
+        },
+      ]);
+
+      const result = selectActionables(snapshot, 'modal', 100);
+
+      // Only dialog button should be included (modal blocks main content)
+      expect(result.length).toBe(1);
+      expect(result[0].label).toBe('Dialog Confirm');
+    });
+
+    it('should include all visible elements when activeLayer is drawer', () => {
+      const snapshot = createTestSnapshot([
+        {
+          kind: 'link',
+          label: 'Main Nav Link',
+          where: { region: 'main' },
+          layout: {
+            bbox: { x: 0, y: 0, w: 100, h: 40 },
+            display: 'block',
+            screen_zone: 'top-center' as const,
+          },
+          state: { visible: true, enabled: true },
+        },
+        {
+          kind: 'button',
+          label: 'Drawer Action',
+          where: { region: 'main' },
+          layout: {
+            bbox: { x: 0, y: 50, w: 100, h: 40 },
+            display: 'block',
+            screen_zone: 'top-center' as const,
+            zIndex: 50,
+          },
+          state: { visible: true, enabled: true },
+        },
+      ]);
+
+      const result = selectActionables(snapshot, 'drawer', 100);
+
+      // Both main and drawer elements should be included
+      expect(result.length).toBe(2);
+      expect(result.some((n) => n.label === 'Main Nav Link')).toBe(true);
+      expect(result.some((n) => n.label === 'Drawer Action')).toBe(true);
+    });
+  });
 });

--- a/tests/unit/state/node-layer.test.ts
+++ b/tests/unit/state/node-layer.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Node Layer Assignment Tests
+ */
+import { describe, it, expect } from 'vitest';
+import { getNodeLayer, INCLUSIVE_OVERLAY_LAYERS } from '../../../src/state/node-layer.js';
+import type { ReadableNode } from '../../../src/snapshot/snapshot.types.js';
+
+function makeNode(overrides: Partial<ReadableNode> = {}): ReadableNode {
+  return {
+    node_id: '1',
+    backend_node_id: 100,
+    frame_id: 'main',
+    loader_id: 'loader-1',
+    kind: 'button',
+    label: 'Test',
+    where: { region: 'main' },
+    layout: { bbox: { x: 0, y: 0, w: 100, h: 40 } },
+    state: { visible: true, enabled: true },
+    find: { primary: '#test', alternates: [] },
+    ...overrides,
+  } as ReadableNode;
+}
+
+describe('INCLUSIVE_OVERLAY_LAYERS', () => {
+  it('should contain popover and drawer', () => {
+    expect(INCLUSIVE_OVERLAY_LAYERS.has('popover')).toBe(true);
+    expect(INCLUSIVE_OVERLAY_LAYERS.has('drawer')).toBe(true);
+  });
+
+  it('should not contain modal or main', () => {
+    expect(INCLUSIVE_OVERLAY_LAYERS.has('modal')).toBe(false);
+    expect(INCLUSIVE_OVERLAY_LAYERS.has('main')).toBe(false);
+  });
+});
+
+describe('getNodeLayer', () => {
+  it('should return "main" for nodes in main region', () => {
+    const node = makeNode({ where: { region: 'main' } });
+    expect(getNodeLayer(node)).toBe('main');
+  });
+
+  it('should return "modal" for nodes in dialog region', () => {
+    const node = makeNode({ where: { region: 'dialog' } });
+    expect(getNodeLayer(node)).toBe('modal');
+  });
+
+  it('should return "main" for nodes with unknown region (default)', () => {
+    const node = makeNode({ where: { region: 'unknown' } });
+    expect(getNodeLayer(node)).toBe('main');
+  });
+
+  describe('with activeLayer context', () => {
+    it('should return "popover" for high z-index nodes when activeLayer is popover', () => {
+      const node = makeNode({
+        where: { region: 'main' },
+        layout: { bbox: { x: 0, y: 0, w: 200, h: 300 }, zIndex: 1300 },
+      });
+      expect(getNodeLayer(node, 'popover')).toBe('popover');
+    });
+
+    it('should return "drawer" for high z-index nodes when activeLayer is drawer', () => {
+      const node = makeNode({
+        where: { region: 'main' },
+        layout: { bbox: { x: 0, y: 0, w: 200, h: 300 }, zIndex: 500 },
+      });
+      expect(getNodeLayer(node, 'drawer')).toBe('drawer');
+    });
+
+    it('should return "main" for nodes with undefined z-index when activeLayer is popover', () => {
+      const node = makeNode({
+        where: { region: 'main' },
+        layout: { bbox: { x: 0, y: 0, w: 200, h: 300 }, zIndex: undefined },
+      });
+      expect(getNodeLayer(node, 'popover')).toBe('main');
+    });
+
+    it('should return "main" for z-index 0 when activeLayer is popover', () => {
+      const node = makeNode({
+        where: { region: 'main' },
+        layout: { bbox: { x: 0, y: 0, w: 200, h: 300 }, zIndex: 0 },
+      });
+      expect(getNodeLayer(node, 'popover')).toBe('main');
+    });
+
+    it('should return "main" for z-index at threshold (1) when activeLayer is popover', () => {
+      const node = makeNode({
+        where: { region: 'main' },
+        layout: { bbox: { x: 0, y: 0, w: 200, h: 300 }, zIndex: 1 },
+      });
+      expect(getNodeLayer(node, 'popover')).toBe('main');
+    });
+
+    it('should return "popover" for z-index just above threshold (2) when activeLayer is popover', () => {
+      const node = makeNode({
+        where: { region: 'main' },
+        layout: { bbox: { x: 0, y: 0, w: 200, h: 300 }, zIndex: 2 },
+      });
+      expect(getNodeLayer(node, 'popover')).toBe('popover');
+    });
+
+    it('should return "modal" for dialog region regardless of activeLayer', () => {
+      const node = makeNode({ where: { region: 'dialog' } });
+      expect(getNodeLayer(node, 'popover')).toBe('modal');
+    });
+
+    it('should return "main" for nodes when activeLayer is main (no change)', () => {
+      const node = makeNode({
+        where: { region: 'main' },
+        layout: { bbox: { x: 0, y: 0, w: 200, h: 300 }, zIndex: 1300 },
+      });
+      expect(getNodeLayer(node, 'main')).toBe('main');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **Extract and fix `getNodeLayer()`** — DRY shared module (`src/state/node-layer.ts`) replaces 3 identical broken copies. Now handles popover/drawer layers via z-index-based assignment.
- **Skip layer filtering for popover/drawer** — These overlays coexist with main content (unlike modals which block), so all visible interactive elements are included when they're active.
- **Overlay-aware `max_nodes` budget** — Portal-rendered content at end of DOM is no longer truncated on heavy pages. Reserves up to 30% of node budget for high z-index overlay content.

## Test plan

- [x] Unit tests for `getNodeLayer()` (13 tests including boundary conditions)
- [x] Layer filtering tests for `selectActionables` (popover, drawer, modal)
- [x] `sliceWithOverlayPriority` tests (budget cap, DOM order preservation, thresholds)
- [x] All 1672 existing tests pass
- [x] Manual browser testing across 9+ sites: MUI, GitHub, Headless UI, Radix UI, Ant Design, Chakra UI, shadcn/ui, Amazon, Wikipedia, Google, Vercel, Stripe

🤖 Generated with [Claude Code](https://claude.com/claude-code)