### PR TITLE
feat(browser): optional fingerprint-only stealth (avoid false-positive bot blocking)

### DIFF
--- a/README.md
+++ b/README.md
@@ -716,6 +716,24 @@ AWI_BROWSER_MODE=persistent npx agent-web-interface
 AWI_BROWSER_MODE=isolated AWI_HEADLESS=true npx agent-web-interface
 ```
 
+### Stealth (`AWI_STEALTH`)
+
+Launched browsers (`persistent`/`isolated`) carry Puppeteer's automation tells —
+`navigator.webdriver`, the "controlled by automated test software" infobar, an empty
+plugins list — which some sites use to false-positive a legitimate session as a bot.
+`AWI_STEALTH` (default `true`) applies **fingerprint-only** patches so a launched Chrome
+looks like your everyday Chrome. It changes nothing about behavior (clicks and typing are
+untouched) and is a **no-op in `user` mode**, where the connected Chrome already has a
+genuine fingerprint.
+
+```bash
+# Disable stealth (raw Puppeteer fingerprint)
+AWI_STEALTH=false AWI_BROWSER_MODE=isolated npx agent-web-interface
+```
+
+This is not a CAPTCHA or anti-bot bypass tool — it only avoids false-positive blocking of
+ordinary, authorized use.
+
 ---
 
 ## Using your existing Chrome

--- a/src/browser/browser-session-config.ts
+++ b/src/browser/browser-session-config.ts
@@ -61,11 +61,14 @@ export function loadBrowserConfig(): BrowserSessionConfig {
   // eslint-disable-next-line @typescript-eslint/prefer-nullish-coalescing -- empty string must be falsy
   const cdpUrl = process.env.AWI_CDP_URL?.trim() || undefined;
 
+  // Stealth defaults ON; disabled only by an explicit falsy value.
+  const stealthRaw = process.env.AWI_STEALTH?.trim().toLowerCase();
+  const stealth = !(stealthRaw !== undefined && ['false', '0', 'no', 'off'].includes(stealthRaw));
+
   return {
     browserMode,
     headless: process.env.AWI_HEADLESS?.trim().toLowerCase() === 'true',
     cdpUrl,
-    // Default ON: only set false when explicitly disabled.
-    stealth: process.env.AWI_STEALTH?.trim().toLowerCase() !== 'false',
+    stealth,
   };
 }

--- a/src/browser/browser-session-config.ts
+++ b/src/browser/browser-session-config.ts
@@ -8,6 +8,8 @@
  *   AWI_BROWSER_MODE  - user | persistent | isolated (default: unset = auto fallback)
  *   AWI_CDP_URL       - Explicit CDP endpoint (overrides mode entirely)
  *   AWI_HEADLESS      - true | false (default: false, only for persistent/isolated)
+ *   AWI_STEALTH       - true | false (default: true) fingerprint-only anti-detection
+ *                       for launched browsers; no-op when connecting to user Chrome
  *
  * @module browser/browser-session-config
  */
@@ -35,6 +37,13 @@ export interface BrowserSessionConfig {
 
   /** Explicit CDP endpoint URL. Overrides browserMode entirely. */
   cdpUrl?: string;
+
+  /**
+   * Apply fingerprint-only anti-detection patches to launched browsers.
+   * Default true. No-op when connecting to the user's real Chrome (it already
+   * has a genuine fingerprint).
+   */
+  stealth?: boolean;
 }
 
 /**
@@ -56,5 +65,7 @@ export function loadBrowserConfig(): BrowserSessionConfig {
     browserMode,
     headless: process.env.AWI_HEADLESS?.trim().toLowerCase() === 'true',
     cdpUrl,
+    // Default ON: only set false when explicitly disabled.
+    stealth: process.env.AWI_STEALTH?.trim().toLowerCase() !== 'false',
   };
 }

--- a/src/browser/ensure-browser.ts
+++ b/src/browser/ensure-browser.ts
@@ -47,7 +47,7 @@ export async function ensureBrowserReady(
   if (config.cdpUrl) {
     logger.info('Connecting to explicit CDP endpoint', { cdpUrl: config.cdpUrl });
     try {
-      await session.connect({ endpointUrl: config.cdpUrl });
+      await session.connect({ endpointUrl: config.cdpUrl, stealth: config.stealth });
       logger.info('Connected to CDP endpoint');
     } catch (error) {
       const msg = extractErrorMessage(error);
@@ -62,7 +62,7 @@ export async function ensureBrowserReady(
   // Explicit mode — try it only, no fallback
   if (config.browserMode) {
     logger.info('Browser mode (explicit)', { mode: config.browserMode });
-    await attemptMode(session, config.browserMode, config.headless);
+    await attemptMode(session, config.browserMode, config);
     return;
   }
 
@@ -72,7 +72,7 @@ export async function ensureBrowserReady(
   for (const mode of AUTO_FALLBACK_CHAIN) {
     try {
       logger.info('Browser mode (auto)', { attempting: mode });
-      await attemptMode(session, mode, config.headless);
+      await attemptMode(session, mode, config);
       return;
     } catch (error) {
       lastError = error instanceof Error ? error : new Error(extractErrorMessage(error));
@@ -92,12 +92,12 @@ export async function ensureBrowserReady(
 async function attemptMode(
   session: SessionManager,
   mode: BrowserMode,
-  headless: boolean
+  config: BrowserSessionConfig
 ): Promise<void> {
   if (mode === 'user') {
     // Puppeteer's channel:'chrome' reads DevToolsActivePort from Chrome's well-known user data dir
     try {
-      await session.connect({ autoConnect: true });
+      await session.connect({ autoConnect: true, stealth: config.stealth });
       logger.info('Connected to user Chrome');
     } catch (error) {
       const msg = extractErrorMessage(error);
@@ -109,7 +109,7 @@ async function attemptMode(
   } else {
     const isolated = mode === 'isolated';
     try {
-      await session.launch({ headless, isolated });
+      await session.launch({ headless: config.headless, isolated, stealth: config.stealth });
       logger.info(`Launched browser (${mode} profile)`);
     } catch (error) {
       const msg = extractErrorMessage(error);

--- a/src/browser/session-manager.ts
+++ b/src/browser/session-manager.ts
@@ -15,6 +15,7 @@ import puppeteer, {
   TargetType,
 } from 'puppeteer-core';
 import { PuppeteerCdpClient } from '../cdp/puppeteer-cdp-client.js';
+import { applyStealthToPage, buildStealthLaunchOptions } from './stealth.js';
 import { PageRegistry, type PageHandle } from './page-registry.js';
 import { getLogger } from '../shared/services/logging.service.js';
 import { BrowserSessionError } from '../shared/errors/browser-session.error.js';
@@ -67,6 +68,10 @@ export class SessionManager {
   private readonly registry: PageRegistry;
   private readonly logger = getLogger();
   private isExternalBrowser = false;
+  /** Whether fingerprint-only stealth is active for this session. */
+  private stealthEnabled = false;
+  /** Whether the browser was launched headless (drives stealth UA normalization). */
+  private launchedHeadless = false;
   /** Connection state machine */
   private _connectionState: ConnectionState = 'idle';
   /** State change listeners */
@@ -173,7 +178,11 @@ export class SessionManager {
       isolated = false,
       userDataDir,
       args = [],
+      stealth = false,
     } = options;
+
+    this.stealthEnabled = stealth;
+    this.launchedHeadless = headless;
 
     // Determine profile directory
     let profileDir: string | undefined;
@@ -198,11 +207,14 @@ export class SessionManager {
     let timeoutId: NodeJS.Timeout | undefined;
 
     try {
-      // Build Chrome args
+      // Build Chrome args. Stealth flags (empty when disabled) suppress the
+      // automation tells; user-supplied args take precedence (appended last).
+      const stealthLaunch = buildStealthLaunchOptions(stealth);
       const chromeArgs = [
         '--hide-crash-restore-bubble',
         '--disable-background-timer-throttling',
         '--disable-backgrounding-occluded-windows',
+        ...stealthLaunch.args,
         ...args,
       ];
 
@@ -214,6 +226,10 @@ export class SessionManager {
         defaultViewport: viewport ?? null,
         pipe,
         args: chromeArgs,
+        // Only set when stealth is on; omitting it preserves Puppeteer defaults.
+        ...(stealthLaunch.ignoreDefaultArgs.length
+          ? { ignoreDefaultArgs: stealthLaunch.ignoreDefaultArgs }
+          : {}),
       });
       const timeoutPromise = new Promise<never>((_, reject) => {
         timeoutId = setTimeout(() => {
@@ -429,6 +445,10 @@ export class SessionManager {
 
       this.browser = browser;
       this.isExternalBrowser = !options.ownedReconnect;
+      // Stealth page injection only runs for owned (non-external) browsers;
+      // connecting to the user's real Chrome already has a genuine fingerprint.
+      this.stealthEnabled = options.stealth ?? false;
+      this.launchedHeadless = false;
 
       // Setup disconnect listener
       this.setupBrowserListeners();
@@ -519,6 +539,11 @@ export class SessionManager {
 
     this.registry.updateMetadata(handle.page_id, { url: page.url() });
 
+    // Adopted tabs are already loaded, so the injected init script only affects
+    // subsequent navigations of this tab — acceptable, and moot for external
+    // (user-Chrome) sessions which skip stealth entirely.
+    await this.applyStealth(handle);
+
     await this.setupPageTracking(page);
 
     this.logger.debug('Adopted page', { page_id: handle.page_id, url: page.url() });
@@ -544,6 +569,9 @@ export class SessionManager {
     const handle = this.registry.register(page, cdpClient);
 
     this.logger.debug('Created page', { page_id: handle.page_id });
+
+    // Apply stealth BEFORE the first navigation so the init script covers it.
+    await this.applyStealth(handle);
 
     if (url) {
       await page.goto(url, { waitUntil: 'domcontentloaded' });
@@ -1194,6 +1222,28 @@ export class SessionManager {
     if (this.browser && this.browserDisconnectHandler) {
       this.browser.off('disconnected', this.browserDisconnectHandler);
       this.browserDisconnectHandler = null;
+    }
+  }
+
+  /**
+   * Apply fingerprint-only stealth to a page, if enabled.
+   *
+   * No-op when stealth is disabled or when connected to an external browser
+   * (the user's real Chrome already has a genuine fingerprint). Must run BEFORE
+   * the first navigation so the injected init script covers the first document.
+   */
+  private async applyStealth(handle: PageHandle): Promise<void> {
+    if (!this.stealthEnabled || this.isExternalBrowser) {
+      return;
+    }
+    try {
+      await applyStealthToPage(handle.cdp, { headless: this.launchedHeadless });
+    } catch (error) {
+      // Stealth is best-effort hardening — never fail page creation over it.
+      this.logger.warning('Stealth injection failed', {
+        page_id: handle.page_id,
+        error: extractErrorMessage(error),
+      });
     }
   }
 

--- a/src/browser/session-manager.types.ts
+++ b/src/browser/session-manager.types.ts
@@ -75,6 +75,12 @@ export interface LaunchOptions {
 
   /** Use pipe transport instead of WebSocket. Defaults to true for isolated profiles, false for persistent (enables reconnection). */
   pipe?: boolean;
+
+  /**
+   * Apply fingerprint-only stealth: suppresses automation launch flags and
+   * injects anti-detection patches into each page. Default false.
+   */
+  stealth?: boolean;
 }
 
 /**
@@ -114,4 +120,11 @@ export interface ConnectOptions {
    * Use when reconnecting to a browser that this server originally launched.
    */
   ownedReconnect?: boolean;
+
+  /**
+   * Apply fingerprint-only stealth to pages. Default false. Only takes effect
+   * for owned (non-external) browsers — connecting to the user's real Chrome is
+   * treated as external and skips injection.
+   */
+  stealth?: boolean;
 }

--- a/src/browser/stealth.ts
+++ b/src/browser/stealth.ts
@@ -1,0 +1,150 @@
+/**
+ * Stealth — fingerprint-only anti-detection for launched browsers.
+ *
+ * Goal: avoid FALSE-POSITIVE bot blocking for legitimate use. A browser launched
+ * by Puppeteer carries automation tells (navigator.webdriver === true, the
+ * "controlled by automated test software" infobar, an empty plugins list,
+ * a missing window.chrome, "HeadlessChrome" in the User-Agent) that some sites
+ * use to block. These patches make a launched Chrome look like the user's normal
+ * Chrome. No behavioral changes (clicks/typing are untouched).
+ *
+ * Only relevant for LAUNCHED browsers (persistent/isolated). When connecting to
+ * the user's real Chrome the fingerprint is already genuine, so the caller skips
+ * page injection entirely — see SessionManager.applyStealth().
+ *
+ * @module browser/stealth
+ */
+
+import type { CdpClient } from '../cdp/cdp-client.interface.js';
+
+/** Launch-time flags that suppress Chrome's automation tells. */
+export interface StealthLaunchOptions {
+  /** Extra Chrome command-line args. */
+  args: string[];
+  /** Default Puppeteer args to omit. */
+  ignoreDefaultArgs: string[];
+}
+
+/**
+ * Build launch flags for stealth. Returns empty arrays when disabled so callers
+ * preserve their current behavior exactly.
+ */
+export function buildStealthLaunchOptions(stealth: boolean): StealthLaunchOptions {
+  if (!stealth) {
+    return { args: [], ignoreDefaultArgs: [] };
+  }
+  return {
+    // Stops Blink from setting navigator.webdriver at the engine level
+    // (belt-and-braces with the JS patch in the evasion script).
+    args: ['--disable-blink-features=AutomationControlled'],
+    // Removes Puppeteer's default --enable-automation switch, which both shows the
+    // automation infobar and is itself a high-signal tell.
+    ignoreDefaultArgs: ['--enable-automation'],
+  };
+}
+
+/**
+ * Build the evasion script injected into every new document before page scripts.
+ *
+ * Kept MINIMAL and fully guarded: a throwing init script is itself a detectable
+ * anomaly (and can corrupt page init), so everything is wrapped in try/catch and
+ * only patches values that look automated (e.g. an empty plugins list).
+ *
+ * @param opts.headless - when true, also strips "HeadlessChrome" from
+ *   navigator.userAgent so JS reads match the wire UA set via
+ *   Network.setUserAgentOverride (identical output ⇒ no mismatch tell).
+ */
+export function buildStealthEvasionScript(opts: { headless: boolean }): string {
+  return `(() => { try {
+    // 1) navigator.webdriver — the canonical Selenium/Puppeteer flag. Launched
+    //    Chrome sets it true; real user Chrome leaves it undefined/false.
+    Object.defineProperty(Navigator.prototype, 'webdriver', { get: () => false, configurable: true });
+    // 2) navigator.plugins / mimeTypes — an empty PluginArray is a common bot
+    //    signal. Real Chrome ships the PDF viewer plugins. Only patch if empty.
+    if (navigator.plugins.length === 0) {
+      const mk = (name, filename, description) => ({ name, filename, description, length: 1 });
+      const plugins = [
+        mk('PDF Viewer', 'internal-pdf-viewer', 'Portable Document Format'),
+        mk('Chrome PDF Viewer', 'internal-pdf-viewer', 'Portable Document Format'),
+        mk('Chromium PDF Viewer', 'internal-pdf-viewer', 'Portable Document Format'),
+      ];
+      Object.defineProperty(navigator, 'plugins', { get: () => plugins, configurable: true });
+      Object.defineProperty(navigator, 'mimeTypes', {
+        get: () => [{ type: 'application/pdf', suffixes: 'pdf', description: '' }],
+        configurable: true,
+      });
+    }
+    // 3) navigator.languages — an empty array is anomalous for a real browser.
+    if (!navigator.languages || navigator.languages.length === 0) {
+      Object.defineProperty(navigator, 'languages', { get: () => ['en-US', 'en'], configurable: true });
+    }
+    // 4) window.chrome.runtime — present in real Chrome; its absence is a strong
+    //    tell. Add a minimal stub only if missing; never clobber a genuine one.
+    if (!window.chrome) {
+      Object.defineProperty(window, 'chrome', { value: { runtime: {} }, writable: true, configurable: true });
+    } else if (!window.chrome.runtime) {
+      window.chrome.runtime = {};
+    }
+    // 5) permissions.query('notifications') — headless returns 'denied' while
+    //    Notification.permission is 'default' (an impossible combo scanners
+    //    check). Reconcile the two.
+    const query = navigator.permissions && navigator.permissions.query;
+    if (query) {
+      navigator.permissions.query = (params) =>
+        params && params.name === 'notifications'
+          ? Promise.resolve({ state: Notification.permission, onchange: null })
+          : query.call(navigator.permissions, params);
+    }${
+      opts.headless
+        ? `
+    // 6) (headless only) strip "HeadlessChrome" from navigator.userAgent so JS
+    //    reads match the wire UA set via Network.setUserAgentOverride.
+    const ua = navigator.userAgent.replace(/HeadlessChrome/g, 'Chrome').replace(/Headless/g, '');
+    Object.defineProperty(Navigator.prototype, 'userAgent', { get: () => ua, configurable: true });`
+        : ''
+    }
+  } catch (e) { /* swallow — an init script must never throw */ } })();`;
+}
+
+/** Options for applying stealth to a page's CDP session. */
+export interface ApplyStealthOptions {
+  /** Whether the browser was launched headless (enables UA normalization). */
+  headless: boolean;
+}
+
+/**
+ * Apply fingerprint-only stealth to a page via its CDP session.
+ *
+ * Uses raw CDP (not Puppeteer's page.evaluateOnNewDocument) so the behavior is
+ * exercised through the CdpClient abstraction the rest of the codebase and tests
+ * use. Page.addScriptToEvaluateOnNewDocument auto-reruns on every new document,
+ * so the evasion persists across navigations with no per-nav re-injection.
+ *
+ * Caller is responsible for skipping this in connect/user mode (real Chrome
+ * already has a genuine fingerprint).
+ */
+export async function applyStealthToPage(cdp: CdpClient, opts: ApplyStealthOptions): Promise<void> {
+  await cdp.send('Page.addScriptToEvaluateOnNewDocument', {
+    source: buildStealthEvasionScript({ headless: opts.headless }),
+  });
+
+  // UA normalization only matters for headless launches, where the UA carries
+  // "HeadlessChrome". setUserAgentOverride is authoritative — it sets both the
+  // wire User-Agent header and navigator.userAgent.
+  if (opts.headless) {
+    let userAgent: string | undefined;
+    try {
+      const version = await cdp.send<{ userAgent?: string }>('Browser.getVersion');
+      userAgent = version?.userAgent;
+    } catch {
+      /* best-effort — Browser.getVersion may be unavailable */
+    }
+    if (userAgent?.includes('Headless')) {
+      const cleanUA = userAgent.replace(/HeadlessChrome/g, 'Chrome').replace(/Headless/g, '');
+      await cdp.send('Network.setUserAgentOverride', {
+        userAgent: cleanUA,
+        acceptLanguage: 'en-US,en;q=0.9',
+      });
+    }
+  }
+}

--- a/src/browser/stealth.ts
+++ b/src/browser/stealth.ts
@@ -92,7 +92,12 @@ export function buildStealthEvasionScript(opts: { headless: boolean }): string {
     if (query) {
       navigator.permissions.query = (params) =>
         params && params.name === 'notifications'
-          ? Promise.resolve({ state: Notification.permission, onchange: null })
+          ? Promise.resolve({
+              // Guard: window.Notification is undefined in insecure/sandboxed
+              // contexts — deref'ing it here would reject the page's own query.
+              state: typeof Notification !== 'undefined' ? Notification.permission : 'default',
+              onchange: null,
+            })
           : query.call(navigator.permissions, params);
     }${
       opts.headless

--- a/tests/integration/stealth.integration.test.ts
+++ b/tests/integration/stealth.integration.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Stealth Integration Tests
+ *
+ * Launches a real Chrome via SessionManager and verifies that fingerprint-only
+ * stealth removes the automation tells (and that disabling it leaves them).
+ *
+ * Skipped in CI unless RUN_INTEGRATION=true (requires Chrome installed).
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { SessionManager } from '../../src/browser/session-manager.js';
+
+// Skip in CI unless RUN_INTEGRATION is set (matches other integration tests)
+const skipIntegration = process.env.CI === 'true' && process.env.RUN_INTEGRATION !== 'true';
+
+const ECHO_URL = 'data:text/html,<html><body>stealth-echo</body></html>';
+
+interface Fingerprint {
+  webdriver: boolean;
+  plugins: number;
+  ua: string;
+  hasChrome: boolean;
+}
+
+// Evaluated in the page context — navigator/window are browser globals there.
+// navigator.webdriver is typed boolean in lib.dom; `'chrome' in window` avoids `any`.
+function readFingerprint(): Fingerprint {
+  return {
+    webdriver: navigator.webdriver,
+    plugins: navigator.plugins.length,
+    ua: navigator.userAgent,
+    hasChrome: 'chrome' in window,
+  };
+}
+
+describe.skipIf(skipIntegration)('Stealth Integration', () => {
+  let session: SessionManager | undefined;
+
+  afterEach(async () => {
+    await session?.shutdown();
+    session = undefined;
+  });
+
+  it('removes automation tells when stealth is on', async () => {
+    session = new SessionManager();
+    await session.launch({ headless: true, isolated: true, stealth: true });
+
+    const handle = await session.createPage(ECHO_URL);
+    const fp = await handle.page.evaluate(readFingerprint);
+
+    expect(fp.webdriver).toBeFalsy();
+    expect(fp.plugins).toBeGreaterThan(0);
+    expect(fp.ua).not.toMatch(/Headless/);
+    expect(fp.hasChrome).toBe(true);
+  }, 30000);
+
+  it('leaves navigator.webdriver set when stealth is off (toggle has teeth)', async () => {
+    session = new SessionManager();
+    await session.launch({ headless: true, isolated: true, stealth: false });
+
+    const handle = await session.createPage(ECHO_URL);
+    const webdriver = await handle.page.evaluate(() => navigator.webdriver);
+
+    expect(webdriver).toBe(true);
+  }, 30000);
+});

--- a/tests/unit/browser/browser-session-config.test.ts
+++ b/tests/unit/browser/browser-session-config.test.ts
@@ -1,0 +1,39 @@
+/**
+ * Browser Session Config Tests
+ *
+ * Covers AWI_STEALTH parsing and its default-ON behavior — the most
+ * user-facing surface of the stealth feature.
+ */
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { loadBrowserConfig } from '../../../src/browser/browser-session-config.js';
+
+describe('loadBrowserConfig — AWI_STEALTH', () => {
+  const original = process.env.AWI_STEALTH;
+
+  afterEach(() => {
+    if (original === undefined) {
+      delete process.env.AWI_STEALTH;
+    } else {
+      process.env.AWI_STEALTH = original;
+    }
+  });
+
+  it('defaults stealth ON when unset', () => {
+    delete process.env.AWI_STEALTH;
+    expect(loadBrowserConfig().stealth).toBe(true);
+  });
+
+  it.each(['false', 'FALSE', '0', 'no', 'off', '  Off  '])(
+    'disables stealth for falsy value %j',
+    (value) => {
+      process.env.AWI_STEALTH = value;
+      expect(loadBrowserConfig().stealth).toBe(false);
+    }
+  );
+
+  it.each(['true', '1', 'yes', ''])('keeps stealth ON for non-falsy value %j', (value) => {
+    process.env.AWI_STEALTH = value;
+    expect(loadBrowserConfig().stealth).toBe(true);
+  });
+});

--- a/tests/unit/browser/ensure-browser.test.ts
+++ b/tests/unit/browser/ensure-browser.test.ts
@@ -193,6 +193,23 @@ describe('ensureBrowserReady', () => {
       expect(sessionManager.isRunning()).toBe(true);
     });
 
+    it('should thread config.stealth through to launch flags', async () => {
+      const ensureBrowserReady = await getEnsureBrowserReady();
+
+      const config: BrowserSessionConfig = {
+        headless: false,
+        browserMode: 'persistent',
+        stealth: true,
+      };
+
+      await ensureBrowserReady(sessionManager, config);
+
+      const launchArgs = (puppeteer.launch as Mock).mock.calls[0][0] as {
+        ignoreDefaultArgs?: string[];
+      };
+      expect(launchArgs.ignoreDefaultArgs).toEqual(['--enable-automation']);
+    });
+
     it('should NOT fall back on failure', async () => {
       const ensureBrowserReady = await getEnsureBrowserReady();
 

--- a/tests/unit/browser/session-manager.test.ts
+++ b/tests/unit/browser/session-manager.test.ts
@@ -180,13 +180,15 @@ describe('SessionManager', () => {
 
       await sessionManager.createPage('https://example.com');
 
-      const injectCall = mockCdpSession.send.mock.calls.find(
+      // Find the actual inject call's invocation order (not an assumed index),
+      // so this stays load-bearing even if other CDP sends are added before it.
+      const injectIdx = mockCdpSession.send.mock.calls.findIndex(
         ([method]) => method === 'Page.addScriptToEvaluateOnNewDocument'
       );
-      expect(injectCall).toBeDefined();
+      expect(injectIdx).toBeGreaterThanOrEqual(0);
 
       // Stealth injection must run BEFORE goto so it covers the first document.
-      const injectOrder = mockCdpSession.send.mock.invocationCallOrder[0];
+      const injectOrder = mockCdpSession.send.mock.invocationCallOrder[injectIdx];
       const gotoOrder = mockPage.goto.mock.invocationCallOrder[0];
       expect(injectOrder).toBeLessThan(gotoOrder);
     });

--- a/tests/unit/browser/session-manager.test.ts
+++ b/tests/unit/browser/session-manager.test.ts
@@ -152,6 +152,57 @@ describe('SessionManager', () => {
     });
   });
 
+  describe('stealth', () => {
+    it('passes automation-suppressing launch flags when stealth is on', async () => {
+      await sessionManager.launch({ stealth: true });
+
+      const launchArgs = vi.mocked(puppeteer.launch).mock.calls[0][0] as {
+        args: string[];
+        ignoreDefaultArgs?: string[];
+      };
+      expect(launchArgs.ignoreDefaultArgs).toEqual(['--enable-automation']);
+      expect(launchArgs.args).toContain('--disable-blink-features=AutomationControlled');
+    });
+
+    it('does not set ignoreDefaultArgs or the blink flag when stealth is off', async () => {
+      await sessionManager.launch({ stealth: false });
+
+      const launchArgs = vi.mocked(puppeteer.launch).mock.calls[0][0] as {
+        args: string[];
+        ignoreDefaultArgs?: string[];
+      };
+      expect(launchArgs.ignoreDefaultArgs).toBeUndefined();
+      expect(launchArgs.args).not.toContain('--disable-blink-features=AutomationControlled');
+    });
+
+    it('injects the evasion script before the first navigation', async () => {
+      await sessionManager.launch({ stealth: true });
+
+      await sessionManager.createPage('https://example.com');
+
+      const injectCall = mockCdpSession.send.mock.calls.find(
+        ([method]) => method === 'Page.addScriptToEvaluateOnNewDocument'
+      );
+      expect(injectCall).toBeDefined();
+
+      // Stealth injection must run BEFORE goto so it covers the first document.
+      const injectOrder = mockCdpSession.send.mock.invocationCallOrder[0];
+      const gotoOrder = mockPage.goto.mock.invocationCallOrder[0];
+      expect(injectOrder).toBeLessThan(gotoOrder);
+    });
+
+    it('does not inject when stealth is off', async () => {
+      await sessionManager.launch({ stealth: false });
+
+      await sessionManager.createPage('https://example.com');
+
+      const injectCall = mockCdpSession.send.mock.calls.find(
+        ([method]) => method === 'Page.addScriptToEvaluateOnNewDocument'
+      );
+      expect(injectCall).toBeUndefined();
+    });
+  });
+
   describe('getPage', () => {
     beforeEach(async () => {
       await sessionManager.launch();
@@ -371,6 +422,19 @@ describe('SessionManager', () => {
         })
       );
       expect(sessionManager.isRunning()).toBe(true);
+    });
+
+    it('skips stealth injection for external browsers even when stealth is on', async () => {
+      // Connecting to the user's real Chrome (external) — already a genuine
+      // fingerprint, so stealth must be a no-op.
+      await sessionManager.connect({ stealth: true });
+
+      await sessionManager.createPage('https://example.com');
+
+      const injectCall = mockCdpSession.send.mock.calls.find(
+        ([method]) => method === 'Page.addScriptToEvaluateOnNewDocument'
+      );
+      expect(injectCall).toBeUndefined();
     });
 
     it('should use custom browserURL', async () => {

--- a/tests/unit/browser/stealth.test.ts
+++ b/tests/unit/browser/stealth.test.ts
@@ -1,0 +1,114 @@
+/**
+ * Stealth Module Tests
+ *
+ * Unit tests for the fingerprint-only anti-detection builders and the
+ * CDP-based page applier.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  buildStealthLaunchOptions,
+  buildStealthEvasionScript,
+  applyStealthToPage,
+} from '../../../src/browser/stealth.js';
+import { MockCdpClient } from '../../mocks/cdp-client.mock.js';
+
+describe('buildStealthLaunchOptions', () => {
+  it('returns automation-suppressing flags when enabled', () => {
+    const opts = buildStealthLaunchOptions(true);
+
+    expect(opts.args).toContain('--disable-blink-features=AutomationControlled');
+    expect(opts.ignoreDefaultArgs).toContain('--enable-automation');
+  });
+
+  it('returns empty arrays when disabled (preserves default behavior)', () => {
+    const opts = buildStealthLaunchOptions(false);
+
+    expect(opts.args).toEqual([]);
+    expect(opts.ignoreDefaultArgs).toEqual([]);
+  });
+});
+
+describe('buildStealthEvasionScript', () => {
+  it('patches the high-signal tells', () => {
+    const script = buildStealthEvasionScript({ headless: false });
+
+    expect(script).toMatch(/webdriver/);
+    expect(script).toMatch(/plugins/);
+    expect(script).toMatch(/window\.chrome/);
+    expect(script).toMatch(/permissions/);
+    expect(script).toMatch(/languages/);
+  });
+
+  it('includes the User-Agent strip only when headless', () => {
+    const headless = buildStealthEvasionScript({ headless: true });
+    const headful = buildStealthEvasionScript({ headless: false });
+
+    expect(headless).toMatch(/HeadlessChrome/);
+    expect(headful).not.toMatch(/HeadlessChrome/);
+  });
+
+  it('is wrapped so it can never throw', () => {
+    const script = buildStealthEvasionScript({ headless: true });
+
+    expect(script).toMatch(/try\s*\{/);
+    expect(script).toMatch(/catch/);
+  });
+});
+
+describe('applyStealthToPage', () => {
+  it('injects the evasion script via addScriptToEvaluateOnNewDocument', async () => {
+    const cdp = new MockCdpClient();
+
+    await applyStealthToPage(cdp, { headless: false });
+
+    const injectCall = cdp.sendSpy.mock.calls.find(
+      ([method]) => method === 'Page.addScriptToEvaluateOnNewDocument'
+    );
+    expect(injectCall).toBeDefined();
+    expect((injectCall![1] as { source: string }).source).toMatch(/webdriver/);
+  });
+
+  it('overrides the User-Agent when headless and UA contains Headless', async () => {
+    const cdp = new MockCdpClient();
+    cdp.setResponse('Browser.getVersion', {
+      userAgent: 'Mozilla/5.0 (X11; Linux x86_64) HeadlessChrome/120.0.0.0 Safari/537.36',
+    });
+
+    await applyStealthToPage(cdp, { headless: true });
+
+    const uaCall = cdp.sendSpy.mock.calls.find(
+      ([method]) => method === 'Network.setUserAgentOverride'
+    );
+    expect(uaCall).toBeDefined();
+    const params = uaCall![1] as { userAgent: string; acceptLanguage: string };
+    expect(params.userAgent).not.toMatch(/Headless/);
+    expect(params.userAgent).toMatch(/Chrome\/120/);
+    expect(params.acceptLanguage).toBe('en-US,en;q=0.9');
+  });
+
+  it('does not override the User-Agent when not headless', async () => {
+    const cdp = new MockCdpClient();
+
+    await applyStealthToPage(cdp, { headless: false });
+
+    const uaCall = cdp.sendSpy.mock.calls.find(
+      ([method]) => method === 'Network.setUserAgentOverride'
+    );
+    expect(uaCall).toBeUndefined();
+  });
+
+  it('skips UA override when a headless build already has a clean UA', async () => {
+    const cdp = new MockCdpClient();
+    cdp.setResponse('Browser.getVersion', {
+      userAgent: 'Mozilla/5.0 (X11; Linux x86_64) Chrome/120.0.0.0 Safari/537.36',
+    });
+
+    await applyStealthToPage(cdp, { headless: true });
+
+    const uaCall = cdp.sendSpy.mock.calls.find(
+      ([method]) => method === 'Network.setUserAgentOverride'
+    );
+    expect(uaCall).toBeUndefined();
+  });
+});

--- a/tests/unit/browser/stealth.test.ts
+++ b/tests/unit/browser/stealth.test.ts
@@ -38,6 +38,8 @@ describe('buildStealthEvasionScript', () => {
     expect(script).toMatch(/window\.chrome/);
     expect(script).toMatch(/permissions/);
     expect(script).toMatch(/languages/);
+    // Notification deref must be guarded so it can't throw on insecure contexts.
+    expect(script).toMatch(/typeof Notification/);
   });
 
   it('includes the User-Agent strip only when headless', () => {


### PR DESCRIPTION
## Why

Launched browsers (`persistent`/`isolated` modes) carry Puppeteer's automation tells — `navigator.webdriver === true`, the *"controlled by automated test software"* infobar, an empty plugins list, `HeadlessChrome` in the UA — which some sites use to **false-positive a legitimate session as a bot** and block it. This adds opt-out fingerprint hardening so a launched Chrome looks like the user's everyday Chrome.

**Not** a CAPTCHA / anti-bot bypass tool — it only avoids false-positive blocking of ordinary, authorized use (the README says as much).

## Scope

- **Fingerprint-only.** No behavioral/input changes — clicks and typing stay instantaneous (preserves the documented parallel-fast-click reCAPTCHA strategy).
- **No new dependency** — a small custom module, not `puppeteer-extra`.
- **`AWI_STEALTH`** env var, **default on**. No-op in `user` mode (connected real Chrome already has a genuine fingerprint) and byte-for-byte unchanged when disabled.

## What it does

- `src/browser/stealth.ts` (new):
  - `buildStealthLaunchOptions` → `--disable-blink-features=AutomationControlled` + `ignoreDefaultArgs: ['--enable-automation']` (only when enabled).
  - `buildStealthEvasionScript` → guarded patch for `navigator.webdriver`, `plugins`/`mimeTypes` (only if empty), `languages`, `window.chrome.runtime`, the `permissions.query('notifications')` anomaly, and a headless-only UA strip.
  - `applyStealthToPage` → injects via CDP `Page.addScriptToEvaluateOnNewDocument` (auto-reruns each navigation); headless UA normalized via `Browser.getVersion` + `Network.setUserAgentOverride`.
- Wired through `BrowserSessionConfig` (`AWI_STEALTH`), `LaunchOptions`/`ConnectOptions`, `ensure-browser`, and `SessionManager` (`applyStealth` helper, skipped for external browsers).
- **Bug fix:** `createPage(url)` ran `goto` before page setup, so an init script would miss the first navigation. Stealth now injects *before* the first `goto`; a test asserts the call order.

## Testing

- Unit: `stealth.test.ts` (builders + applier), plus SessionManager cases — launch flags on/off, inject-before-goto ordering, connect-mode no-op.
- Integration (`stealth.integration.test.ts`, real Chrome, `skipIf` CI gate): stealth on → `navigator.webdriver` falsy, `plugins > 0`, no `Headless` in UA, `window.chrome` present; stealth off → `navigator.webdriver === true` (toggle has teeth).
- Verified end-to-end through the live MCP server in `isolated` launched mode: `{"webdriver":false,"plugins":5,"hasChrome":true,"ua":"…Chrome/148…"}`.
- `npm run check` (type-check + lint + format) and full suite (1729 tests) green; pre-commit hook re-ran them on commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)