### PR TITLE
chore(skills): fix stale skills-lock.json after skill rename

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,6 @@ Thumbs.db
 
 # Local symlink (root-level only; must not match skills/agent-web-interface/)
 /agent-web-interface
+
+# Agent skill install dir (regenerable via `npx skills experimental_install`; source is skills/)
+.agents/

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "agent-web-interface": {
+      "source": "lespaceman/agent-web-interface",
+      "sourceType": "github",
+      "skillPath": "skills/agent-web-interface/SKILL.md",
+      "computedHash": "c70186a3141a70770d25966590bf143baf31ac3e059f4a41b58524a8f8a4e1e2"
+    }
+  }
+}


### PR DESCRIPTION
## Summary

After the `agent-web-interface-guide` → `agent-web-interface` rename, the local `skills-lock.json` still pinned the **old name** at a path that no longer exists (`skills/agent-web-interface-guide/SKILL.md`). That broke `npx skills experimental_install` and made the skill listing show the stale name.

- Replace the stale entry with a single `agent-web-interface` entry sourced from GitHub at the correct path (`skills/agent-web-interface/SKILL.md`), so a fresh clone can restore it via `npx skills experimental_install`.
- Gitignore `.agents/` — the regenerable install dir (analogous to `node_modules`); the source of truth lives in `skills/`.

## Notes
- The published repo was already correct: `npx skills add lespaceman/agent-web-interface -l` discovers exactly one skill, `agent-web-interface`, with the current description.
- Correct install command is the shorthand **`npx skills add lespaceman/agent-web-interface`** (already in the README). The `--skill agent-web-interface-guide` form some registry pages show references the renamed-away skill — that's a stale registry cache, not a repo issue.

## Test plan
- Pre-commit: prettier clean, `tsc --noEmit` clean, 78 files / 1741 tests pass.
- `node -e` JSON validity check + `npx skills ls` show a single correct `agent-web-interface` entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)