### PR TITLE
docs: add install design docs (ADR-0002, ADR-0003, CONTEXT.md glossary)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,8 +1,30 @@
 # Agent Web Interface
 
-An MCP server for AI-driven browser automation. It produces semantic page snapshots and exposes tools for an AI agent to observe and act on web pages. This glossary covers the language of the **non-DOM interaction channel** — capabilities for everything that happens outside the page DOM.
+An MCP server for AI-driven browser automation. It produces semantic page snapshots and exposes tools for an AI agent to observe and act on web pages.
 
 ## Language
+
+### Setup & distribution
+
+**Harness**:
+An AI client that consumes the MCP server and/or the skill. v1 targets four: Claude Code, Cursor, VS Code, and Claude Desktop. Each has its own config location and guidance format.
+_Avoid_: client, IDE, editor (too narrow)
+
+**Install**:
+The single setup command (`agent-web-interface install`) that, for each chosen harness, performs MCP registration and places the skill.
+
+**MCP registration**:
+Adding the agent-web-interface server to a harness's configuration so its `mcp__agent-web-interface__*` tools become available.
+
+**Skill**:
+A single portable guidance document (canonical `SKILL.md` body, **no tool-gating**) that teaches an agent to drive the tools well. Delivered to every harness, wrapped for that harness's native format and location.
+_Avoid_: rule, instructions (those are per-harness wrappings of the skill)
+
+**Install scope**:
+Where setup is written: **project** (the current repo) or **user/global** (home-dir configs). Claude Desktop is always global — it has no project concept.
+
+**Detection**:
+Whether a harness is present on the machine, used to pre-select it for confirmation.
 
 ### Non-DOM interaction channel
 

--- a/docs/adr/0002-portable-gating-free-skill.md
+++ b/docs/adr/0002-portable-gating-free-skill.md
@@ -1,0 +1,11 @@
+# The skill is one portable, tool-gating-free document delivered to every harness
+
+The agent-web-interface skill was a Claude-Code Agent Skill whose frontmatter gated tools via `allowed-tools: mcp__agent-web-interface__*`. To let `agent-web-interface install` deliver the same guidance to every harness, we drop `allowed-tools` from the canonical `SKILL.md` and treat it as a single portable document. Each harness adapter re-wraps the identical body for its native format and location — Claude Code skill (`.claude/skills/…/SKILL.md`), Cursor rule (`.cursor/rules/agent-web-interface.mdc`), and VS Code (GitHub Copilot instructions, `.github/instructions/agent-web-interface.instructions.md`). Claude Desktop has no filesystem drop and is skipped with a note.
+
+We considered keeping the gated Claude-only skill and authoring separate per-harness guidance, but that means three documents drifting out of sync as the tool set evolves, for weaker payoff. A single source with mechanical per-harness wrapping keeps the prose canonical.
+
+## Consequences
+
+- Removing `allowed-tools` changes the published skill's Claude Code behavior: when active it no longer restricts the agent to the browser tools. This is intended — portability over gating.
+- Editing the canonical `SKILL.md` invalidates `skills-lock.json`'s `computedHash`; it must be regenerated so the external `npx skills` consumers stay valid.
+- Cursor/VS Code receive the skill as a rule/instructions file; Claude Desktop receives the MCP server only.

--- a/docs/adr/0003-keep-npx-skills-alongside-installer.md
+++ b/docs/adr/0003-keep-npx-skills-alongside-installer.md
@@ -1,0 +1,10 @@
+# Keep `npx skills` alongside the first-party installer
+
+The new `agent-web-interface install` command registers the MCP server and places the skill in one step and becomes the canonical setup path in the README. The non-obvious decision recorded here is that we deliberately keep the older `npx skills add lespaceman/agent-web-interface` path — and its `skills-lock.json` and `.agents/` — working rather than deleting them once the first-party installer exists.
+
+We keep it because that path belongs to the open skills ecosystem, which other agent runners we don't control rely on for discovery; removing it would break external consumers for no benefit. So two skill-install mechanisms coexist on purpose: the first-party installer is primary, `npx skills add` is demoted to a skill-only/advanced alternative.
+
+## Consequences
+
+- Two ways to install the skill exist on purpose; the README must make the first-party installer clearly primary to avoid confusing readers.
+- `skills-lock.json` is maintained for the external ecosystem even though the installer never reads it.


### PR DESCRIPTION
## Summary

- Adds CONTEXT.md glossary section: Harness, Install, MCP registration, Skill, Install scope, Detection
- Adds `docs/adr/0002-portable-gating-free-skill.md`: skill is one portable tool-gating-free doc wrapped per harness
- Adds `docs/adr/0003-keep-npx-skills-alongside-installer.md`: installer is canonical; `npx skills` kept on purpose

These docs are referenced by issues #64–#73 and must be on `main` before feature PRs.

## Test plan
- [x] All 1741 existing tests pass (`npm run check` green)
- [x] No `apple-cart-journey-mcp-design.md` swept in

🤖 Generated with [Claude Code](https://claude.com/claude-code)