### PR TITLE
feat(#64): install dispatch + Claude Code MCP registration

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -14,3 +14,7 @@ node_modules/
 AGENTS.md
 docs/tooling-plan.md
 docs/engineering-plan.md
+
+# Session trackers and unrelated working docs
+.athena/
+docs/apple-cart-journey-mcp-design.md

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "main": "dist/src/index.js",
   "bin": {
-    "agent-web-interface-dev": "./dist/src/index.js"
+    "agent-web-interface": "./dist/src/index.js"
   },
   "scripts": {
     "build": "tsc --project tsconfig.build.json",

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -1,0 +1,44 @@
+import { VERSION } from '../shared/version.js';
+import { runInstall, type InstallDeps } from '../install/index.js';
+
+export interface DispatchDeps extends InstallDeps {
+  runInstall?: (argv: string[]) => Promise<void>;
+}
+
+export interface DispatchResult {
+  handled: boolean;
+}
+
+export async function dispatch(argv: string[], deps?: DispatchDeps): Promise<DispatchResult> {
+  const verb = argv[0];
+
+  if (verb === '--version') {
+    process.stderr.write(`${VERSION}\n`);
+    process.exit(0);
+    return { handled: true };
+  }
+
+  if (verb === '--help') {
+    process.stderr.write(
+      'Usage: agent-web-interface [command]\n\n' +
+        'Commands:\n' +
+        '  install --harness <harness>   Register MCP server and place skill\n' +
+        '\n' +
+        'Supported harnesses: claude-code\n' +
+        '\n' +
+        'Server mode (default, no command):\n' +
+        '  --transport stdio|http        Transport mode (default: stdio)\n' +
+        '  --port <n>                    HTTP port (default: 3000)\n'
+    );
+    process.exit(0);
+    return { handled: true };
+  }
+
+  if (verb === 'install') {
+    const installFn = deps?.runInstall ?? ((a: string[]) => runInstall(a, deps));
+    await installFn(argv);
+    return { handled: true };
+  }
+
+  return { handled: false };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ import { cleanupTempFiles } from './lib/temp-file.js';
 import { VERSION } from './shared/version.js';
 import { SessionRouter } from './gateway/session-router.js';
 import { registerAllTools } from './tools/tool-registration.js';
+import { dispatch } from './cli/dispatch.js';
 
 /**
  * Initialize all services and start the server
@@ -42,6 +43,14 @@ function initializeServer(): { server: BrowserAutomationServer; router: SessionR
  */
 async function main(): Promise<void> {
   try {
+    // Dispatch install/doctor/--help/--version BEFORE touching stdout (JSON-RPC path).
+    const argv = process.argv.slice(2);
+    const dispatched = await dispatch(argv);
+    if (dispatched.handled) {
+      process.exit(0);
+      return;
+    }
+
     // Check for HTTP transport mode before initializing the stdio server.
     // We parse early to detect the transport flag, then delegate to http-entry.
     const transportIdx = process.argv.indexOf('--transport');

--- a/src/install/harness/claude-code.ts
+++ b/src/install/harness/claude-code.ts
@@ -1,0 +1,51 @@
+import { spawn } from 'node:child_process';
+
+export type CommandRunner = (cmd: string, args: string[]) => Promise<number>;
+
+export interface ClaudeCodeInstallDeps {
+  runner?: CommandRunner;
+}
+
+const SERVER_NAME = 'agent-web-interface';
+const CLAUDE_MCP_ADD_ARGS = ['mcp', 'add', SERVER_NAME, 'npx', '-y', 'agent-web-interface@latest'];
+
+function makeDefaultRunner(): CommandRunner {
+  return (cmd, args) =>
+    new Promise((resolve, reject) => {
+      const child = spawn(cmd, args, { stdio: 'inherit' });
+      child.on('close', (code) => resolve(code ?? 0));
+      child.on('error', reject);
+    });
+}
+
+function isNotFound(err: unknown): boolean {
+  const e = err as NodeJS.ErrnoException;
+  return e.code === 'ENOENT' || /ENOENT|not found|command not found/i.test(e.message ?? '');
+}
+
+export async function runClaudeCodeInstall(deps?: ClaudeCodeInstallDeps): Promise<void> {
+  const run = deps?.runner ?? makeDefaultRunner();
+
+  try {
+    const exitCode = await run('claude', CLAUDE_MCP_ADD_ARGS);
+    if (exitCode !== 0) {
+      process.stderr.write(`claude mcp add exited with code ${exitCode}\n`);
+      process.exit(exitCode);
+      return;
+    }
+    process.stderr.write(`✓ agent-web-interface registered in Claude Code\n`);
+  } catch (err) {
+    if (isNotFound(err)) {
+      process.stderr.write(
+        'Error: The `claude` CLI was not found on PATH.\n' +
+          'Install Claude Code from https://claude.ai/code, then re-run:\n' +
+          '  agent-web-interface install --harness claude-code\n' +
+          'Alternatively, use the .mcp.json fallback (available in a future update).\n'
+      );
+    } else {
+      const msg = (err as Error).message ?? String(err);
+      process.stderr.write(`Error registering with Claude Code: ${msg}\n`);
+    }
+    process.exit(1);
+  }
+}

--- a/src/install/index.ts
+++ b/src/install/index.ts
@@ -1,0 +1,39 @@
+import { runClaudeCodeInstall, type CommandRunner } from './harness/claude-code.js';
+
+export type { CommandRunner };
+
+export interface InstallDeps {
+  claudeCodeRunner?: CommandRunner;
+}
+
+const SUPPORTED_HARNESSES = ['claude-code'] as const;
+type SupportedHarness = (typeof SUPPORTED_HARNESSES)[number];
+
+function parseHarness(argv: string[]): SupportedHarness | undefined {
+  const idx = argv.indexOf('--harness');
+  if (idx === -1) return undefined;
+  const value = argv[idx + 1];
+  if (SUPPORTED_HARNESSES.includes(value as SupportedHarness)) {
+    return value as SupportedHarness;
+  }
+  return undefined;
+}
+
+export async function runInstall(argv: string[], deps?: InstallDeps): Promise<void> {
+  const harness = parseHarness(argv);
+
+  if (!harness) {
+    process.stderr.write(
+      'Usage: agent-web-interface install --harness <harness>\n' +
+        `Supported harnesses: ${SUPPORTED_HARNESSES.join(', ')}\n`
+    );
+    process.exit(1);
+    return;
+  }
+
+  switch (harness) {
+    case 'claude-code':
+      await runClaudeCodeInstall({ runner: deps?.claudeCodeRunner });
+      break;
+  }
+}

--- a/tests/unit/cli/dispatch.test.ts
+++ b/tests/unit/cli/dispatch.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from 'vitest';
+import { dispatch } from '../../../src/cli/dispatch.js';
+
+describe('dispatch', () => {
+  it('returns handled=false for empty argv (server path)', async () => {
+    const result = await dispatch([]);
+    expect(result.handled).toBe(false);
+  });
+
+  it('returns handled=false for unknown verb', async () => {
+    const result = await dispatch(['unknown-verb']);
+    expect(result.handled).toBe(false);
+  });
+
+  it('returns handled=false for server flags', async () => {
+    const result = await dispatch(['--transport', 'stdio']);
+    expect(result.handled).toBe(false);
+  });
+
+  it('handles install verb by calling runInstall', async () => {
+    const runInstallFn = vi.fn().mockResolvedValue(undefined);
+    const result = await dispatch(['install', '--harness', 'claude-code'], {
+      runInstall: runInstallFn as (argv: string[]) => Promise<void>,
+    });
+    expect(result.handled).toBe(true);
+    expect(runInstallFn).toHaveBeenCalledWith(['install', '--harness', 'claude-code']);
+  });
+
+  it('handles --version flag', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockReturnValue(undefined as never);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    const result = await dispatch(['--version']);
+    expect(result.handled).toBe(true);
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('handles --help flag', async () => {
+    const exitSpy = vi.spyOn(process, 'exit').mockReturnValue(undefined as never);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    const result = await dispatch(['--help']);
+    expect(result.handled).toBe(true);
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('does not write to stdout on server path', async () => {
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    await dispatch([]);
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    stdoutSpy.mockRestore();
+  });
+
+  it('does not write to stdout for server flags', async () => {
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    await dispatch(['--transport', 'stdio']);
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    stdoutSpy.mockRestore();
+  });
+});

--- a/tests/unit/install/harness/claude-code.test.ts
+++ b/tests/unit/install/harness/claude-code.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, vi } from 'vitest';
+import {
+  runClaudeCodeInstall,
+  type CommandRunner,
+} from '../../../../src/install/harness/claude-code.js';
+
+describe('runClaudeCodeInstall', () => {
+  it('invokes claude mcp add with the correct argv', async () => {
+    const calls: [string, string[]][] = [];
+    const runner: CommandRunner = (cmd, args) => {
+      calls.push([cmd, args]);
+      return Promise.resolve(0);
+    };
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    await runClaudeCodeInstall({ runner });
+
+    expect(calls).toHaveLength(1);
+    const [cmd, args] = calls[0];
+    expect(cmd).toBe('claude');
+    expect(args).toEqual([
+      'mcp',
+      'add',
+      'agent-web-interface',
+      'npx',
+      '-y',
+      'agent-web-interface@latest',
+    ]);
+    stderrSpy.mockRestore();
+  });
+
+  it('exits non-zero with actionable message when claude is not found (ENOENT)', async () => {
+    const runner: CommandRunner = () => {
+      const err = new Error('spawn claude ENOENT') as NodeJS.ErrnoException;
+      err.code = 'ENOENT';
+      return Promise.reject(err);
+    };
+    const exitSpy = vi.spyOn(process, 'exit').mockReturnValue(undefined as never);
+    const stderrChunks: string[] = [];
+    const stderrSpy = vi
+      .spyOn(process.stderr, 'write')
+      .mockImplementation((chunk: string | Uint8Array) => {
+        stderrChunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString());
+        return true;
+      });
+
+    await runClaudeCodeInstall({ runner });
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    const stderrOutput = stderrChunks.join('');
+    expect(stderrOutput).toMatch(/claude/i);
+    expect(stderrOutput).toMatch(/not found|not installed|install/i);
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('exits non-zero when claude CLI returns non-zero exit code', async () => {
+    const runner: CommandRunner = () => Promise.resolve(2);
+    const exitSpy = vi.spyOn(process, 'exit').mockReturnValue(undefined as never);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    await runClaudeCodeInstall({ runner });
+
+    expect(exitSpy).toHaveBeenCalledWith(2);
+    stderrSpy.mockRestore();
+    exitSpy.mockRestore();
+  });
+
+  it('does not write to stdout', async () => {
+    const runner: CommandRunner = () => Promise.resolve(0);
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
+    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+
+    await runClaudeCodeInstall({ runner });
+
+    expect(stdoutSpy).not.toHaveBeenCalled();
+    stdoutSpy.mockRestore();
+    stderrSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Closes #64

## Summary

- Rename published bin: `agent-web-interface-dev` → `agent-web-interface`
- `dispatch()` reads `argv[2]` **before** anything touches stdout (JSON-RPC safe)
- `install --harness claude-code` shells out to `claude mcp add agent-web-interface npx -y agent-web-interface@latest` via an **injectable CommandRunner** — tests assert the argv without spawning real `claude`
- When `claude` CLI is absent (ENOENT), exits 1 with an actionable message pointing at the fallback (coming in #66)
- `--help` and `--version` write to stderr and exit; unknown verbs fall through to the existing MCP server path unchanged
- `.prettierignore` updated to exclude `.athena/` tracker and unrelated `docs/apple-cart-journey-mcp-design.md`

## Test plan
- [x] 12 new unit tests: dispatch routing, CC argv via injected runner, stdout cleanliness, ENOENT handling
- [x] All 1753 tests pass (`npm run check` green)
- [x] Stdout cleanliness invariant tested: `dispatch([])` never calls `process.stdout.write`

🤖 Generated with [Claude Code](https://claude.com/claude-code)