### PR TITLE
feat(#66): config-io + HarnessAdapter interface + Claude Code .mcp.json fallback

### DIFF
--- a/src/install/config-io.ts
+++ b/src/install/config-io.ts
@@ -1,0 +1,76 @@
+import { readFile, writeFile, rename, copyFile, stat } from 'node:fs/promises';
+import { dirname, join } from 'node:path';
+
+export interface MergeResult {
+  merged: Record<string, unknown>;
+  changed: boolean;
+}
+
+export interface WriteResult {
+  changed: boolean;
+  dryRun: boolean;
+}
+
+export async function readJsonConfig(path: string): Promise<Record<string, unknown>> {
+  try {
+    const content = await readFile(path, 'utf-8');
+    return JSON.parse(content) as Record<string, unknown>;
+  } catch {
+    return {};
+  }
+}
+
+export function mergeAtPath(
+  existing: Record<string, unknown>,
+  keyPath: string[],
+  value: unknown
+): MergeResult {
+  const [head, ...tail] = keyPath;
+  if (!head) return { merged: existing, changed: false };
+
+  if (tail.length === 0) {
+    const existingStr = JSON.stringify(existing[head]);
+    const valueStr = JSON.stringify(value);
+    if (existingStr === valueStr) {
+      return { merged: existing, changed: false };
+    }
+    return { merged: { ...existing, [head]: value }, changed: true };
+  }
+
+  const existingChild = (existing[head] ?? {}) as Record<string, unknown>;
+  const { merged: mergedChild, changed } = mergeAtPath(existingChild, tail, value);
+  if (!changed) return { merged: existing, changed: false };
+
+  return { merged: { ...existing, [head]: mergedChild }, changed: true };
+}
+
+export async function writeJsonAtomic(
+  path: string,
+  data: Record<string, unknown>,
+  opts?: { dryRun?: boolean }
+): Promise<WriteResult> {
+  if (opts?.dryRun) {
+    return { changed: true, dryRun: true };
+  }
+
+  const content = JSON.stringify(data, null, 2) + '\n';
+
+  // Backup pre-existing file
+  try {
+    await stat(path);
+    await copyFile(path, path + '.bak');
+  } catch {
+    // File does not exist — no backup needed
+  }
+
+  // Atomic write: temp file → rename
+  const dir = dirname(path);
+  const tmp = join(
+    dir,
+    `.awi-tmp-${Date.now()}-${Math.floor(Math.random() * 0xffffff).toString(16)}`
+  );
+  await writeFile(tmp, content, 'utf-8');
+  await rename(tmp, path);
+
+  return { changed: true, dryRun: false };
+}

--- a/src/install/harness-adapter.ts
+++ b/src/install/harness-adapter.ts
@@ -1,0 +1,42 @@
+export interface ServerCommand {
+  command: string;
+  args: string[];
+  env?: Record<string, string>;
+}
+
+export type InstallScope = 'project' | 'user' | 'global';
+
+export interface ApplyOpts {
+  scope: InstallScope;
+  dryRun?: boolean;
+  cwd?: string;
+  homeDir?: string;
+}
+
+export interface ApplyResult {
+  changed: boolean;
+  dryRun: boolean;
+  message: string;
+}
+
+export interface StatusOpts {
+  scope: InstallScope;
+  cwd?: string;
+  homeDir?: string;
+}
+
+export interface HarnessStatus {
+  configured: boolean;
+  message: string;
+}
+
+export interface HarnessAdapter {
+  readonly id: string;
+  readonly label: string;
+  readonly supportsSkill: boolean;
+  readonly scopes: readonly InstallScope[];
+  readonly serverCommand: ServerCommand;
+  detect(): Promise<boolean>;
+  apply(opts: ApplyOpts): Promise<ApplyResult>;
+  status(opts: StatusOpts): Promise<HarnessStatus>;
+}

--- a/src/install/harness/claude-code.ts
+++ b/src/install/harness/claude-code.ts
@@ -1,13 +1,35 @@
 import { spawn } from 'node:child_process';
+import { join } from 'node:path';
+import type {
+  HarnessAdapter,
+  ApplyOpts,
+  ApplyResult,
+  StatusOpts,
+  HarnessStatus,
+  ServerCommand,
+} from '../harness-adapter.js';
+import { readJsonConfig, mergeAtPath, writeJsonAtomic } from '../config-io.js';
 
 export type CommandRunner = (cmd: string, args: string[]) => Promise<number>;
 
-export interface ClaudeCodeInstallDeps {
+export interface ClaudeCodeAdapterDeps {
   runner?: CommandRunner;
 }
 
 const SERVER_NAME = 'agent-web-interface';
-const CLAUDE_MCP_ADD_ARGS = ['mcp', 'add', SERVER_NAME, 'npx', '-y', 'agent-web-interface@latest'];
+
+const SERVER_COMMAND: ServerCommand = {
+  command: 'npx',
+  args: ['-y', 'agent-web-interface@latest'],
+};
+
+const CLAUDE_MCP_ADD_ARGS = [
+  'mcp',
+  'add',
+  SERVER_NAME,
+  SERVER_COMMAND.command,
+  ...SERVER_COMMAND.args,
+];
 
 function makeDefaultRunner(): CommandRunner {
   return (cmd, args) =>
@@ -23,29 +45,88 @@ function isNotFound(err: unknown): boolean {
   return e.code === 'ENOENT' || /ENOENT|not found|command not found/i.test(e.message ?? '');
 }
 
-export async function runClaudeCodeInstall(deps?: ClaudeCodeInstallDeps): Promise<void> {
-  const run = deps?.runner ?? makeDefaultRunner();
+export class ClaudeCodeAdapter implements HarnessAdapter {
+  readonly id = 'claude-code';
+  readonly label = 'Claude Code';
+  readonly supportsSkill = true;
+  readonly scopes = ['project', 'user'] as const;
+  readonly serverCommand = SERVER_COMMAND;
 
-  try {
-    const exitCode = await run('claude', CLAUDE_MCP_ADD_ARGS);
-    if (exitCode !== 0) {
-      process.stderr.write(`claude mcp add exited with code ${exitCode}\n`);
-      process.exit(exitCode);
-      return;
+  private readonly run: CommandRunner;
+
+  constructor(deps?: ClaudeCodeAdapterDeps) {
+    this.run = deps?.runner ?? makeDefaultRunner();
+  }
+
+  async detect(): Promise<boolean> {
+    try {
+      const exitCode = await this.run('claude', ['--version']);
+      return exitCode === 0;
+    } catch {
+      return false;
     }
-    process.stderr.write(`✓ agent-web-interface registered in Claude Code\n`);
-  } catch (err) {
-    if (isNotFound(err)) {
-      process.stderr.write(
-        'Error: The `claude` CLI was not found on PATH.\n' +
-          'Install Claude Code from https://claude.ai/code, then re-run:\n' +
-          '  agent-web-interface install --harness claude-code\n' +
-          'Alternatively, use the .mcp.json fallback (available in a future update).\n'
-      );
-    } else {
-      const msg = (err as Error).message ?? String(err);
-      process.stderr.write(`Error registering with Claude Code: ${msg}\n`);
+  }
+
+  async apply(opts: ApplyOpts): Promise<ApplyResult> {
+    const { dryRun = false, cwd = process.cwd() } = opts;
+
+    // Try claude mcp add first
+    let claudeAbsent = false;
+    try {
+      const exitCode = await this.run('claude', CLAUDE_MCP_ADD_ARGS);
+      if (exitCode !== 0) {
+        throw new Error(`claude mcp add exited with code ${exitCode}`);
+      }
+      return {
+        changed: true,
+        dryRun: false,
+        message: '✓ Registered in Claude Code via `claude mcp add`',
+      };
+    } catch (err) {
+      if (!isNotFound(err)) throw err;
+      claudeAbsent = true;
     }
-    process.exit(1);
+
+    if (!claudeAbsent) {
+      // unreachable — satisfies type narrowing
+      throw new Error('unexpected state');
+    }
+
+    // Fallback: write .mcp.json
+    const mcpJsonPath = join(cwd, '.mcp.json');
+    const existing = await readJsonConfig(mcpJsonPath);
+    const { merged, changed } = mergeAtPath(existing, ['mcpServers', SERVER_NAME], {
+      command: SERVER_COMMAND.command,
+      args: SERVER_COMMAND.args,
+    });
+
+    if (!changed) {
+      return {
+        changed: false,
+        dryRun,
+        message: 'Already configured in .mcp.json (no changes needed)',
+      };
+    }
+
+    const result = await writeJsonAtomic(mcpJsonPath, merged, { dryRun });
+    return {
+      changed: result.changed,
+      dryRun: result.dryRun,
+      message: dryRun
+        ? 'Would write .mcp.json (--dry-run)'
+        : '✓ Registered in Claude Code via .mcp.json',
+    };
+  }
+
+  async status(opts: StatusOpts): Promise<HarnessStatus> {
+    const { cwd = process.cwd() } = opts;
+    const mcpJsonPath = join(cwd, '.mcp.json');
+    const existing = await readJsonConfig(mcpJsonPath);
+    const mcpServers = existing.mcpServers as Record<string, unknown> | undefined;
+    const configured = mcpServers?.[SERVER_NAME] != null;
+    return {
+      configured,
+      message: configured ? 'Configured in .mcp.json' : 'Not configured',
+    };
   }
 }

--- a/src/install/index.ts
+++ b/src/install/index.ts
@@ -1,4 +1,4 @@
-import { runClaudeCodeInstall, type CommandRunner } from './harness/claude-code.js';
+import { ClaudeCodeAdapter, type CommandRunner } from './harness/claude-code.js';
 
 export type { CommandRunner };
 
@@ -21,6 +21,7 @@ function parseHarness(argv: string[]): SupportedHarness | undefined {
 
 export async function runInstall(argv: string[], deps?: InstallDeps): Promise<void> {
   const harness = parseHarness(argv);
+  const dryRun = argv.includes('--dry-run');
 
   if (!harness) {
     process.stderr.write(
@@ -31,9 +32,20 @@ export async function runInstall(argv: string[], deps?: InstallDeps): Promise<vo
     return;
   }
 
-  switch (harness) {
-    case 'claude-code':
-      await runClaudeCodeInstall({ runner: deps?.claudeCodeRunner });
-      break;
+  try {
+    let message: string;
+    switch (harness) {
+      case 'claude-code': {
+        const adapter = new ClaudeCodeAdapter({ runner: deps?.claudeCodeRunner });
+        const result = await adapter.apply({ scope: 'project', dryRun });
+        message = result.message;
+        break;
+      }
+    }
+    process.stderr.write(message + '\n');
+  } catch (err) {
+    const msg = (err as Error).message ?? String(err);
+    process.stderr.write(`Error: ${msg}\n`);
+    process.exit(1);
   }
 }

--- a/tests/unit/install/config-io.test.ts
+++ b/tests/unit/install/config-io.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm, readFile, writeFile, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { readJsonConfig, mergeAtPath, writeJsonAtomic } from '../../../src/install/config-io.js';
+
+async function makeTmpDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'awi-config-io-test-'));
+}
+
+async function cleanup(dir: string): Promise<void> {
+  await rm(dir, { recursive: true, force: true });
+}
+
+describe('mergeAtPath', () => {
+  it('inserts a new nested key without clobbering siblings', () => {
+    const existing = {
+      mcpServers: { other: { command: 'other-cmd', args: [] } },
+      unrelated: 'keep-me',
+    };
+    const { merged, changed } = mergeAtPath(existing, ['mcpServers', 'agent-web-interface'], {
+      command: 'npx',
+      args: ['-y', 'agent-web-interface@latest'],
+    });
+
+    expect(changed).toBe(true);
+    expect(merged.unrelated).toBe('keep-me');
+    expect((merged.mcpServers as Record<string, unknown>).other).toEqual({
+      command: 'other-cmd',
+      args: [],
+    });
+    expect((merged.mcpServers as Record<string, unknown>)['agent-web-interface']).toEqual({
+      command: 'npx',
+      args: ['-y', 'agent-web-interface@latest'],
+    });
+  });
+
+  it('returns changed=false when the value is already present and identical', () => {
+    const existing = {
+      mcpServers: {
+        'agent-web-interface': { command: 'npx', args: ['-y', 'agent-web-interface@latest'] },
+      },
+    };
+    const { changed } = mergeAtPath(existing, ['mcpServers', 'agent-web-interface'], {
+      command: 'npx',
+      args: ['-y', 'agent-web-interface@latest'],
+    });
+    expect(changed).toBe(false);
+  });
+
+  it('creates intermediate keys when they are missing', () => {
+    const { merged, changed } = mergeAtPath({}, ['mcpServers', 'agent-web-interface'], {
+      command: 'npx',
+      args: [],
+    });
+    expect(changed).toBe(true);
+    expect((merged.mcpServers as Record<string, unknown>)['agent-web-interface']).toEqual({
+      command: 'npx',
+      args: [],
+    });
+  });
+});
+
+describe('readJsonConfig', () => {
+  it('returns {} when file does not exist', async () => {
+    const result = await readJsonConfig('/nonexistent/path/file.json');
+    expect(result).toEqual({});
+  });
+
+  it('returns parsed JSON when file exists', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const path = join(dir, 'config.json');
+      await writeFile(path, JSON.stringify({ foo: 'bar' }));
+      const result = await readJsonConfig(path);
+      expect(result).toEqual({ foo: 'bar' });
+    } finally {
+      await cleanup(dir);
+    }
+  });
+});
+
+describe('writeJsonAtomic', () => {
+  it('writes new file correctly', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const path = join(dir, 'config.json');
+      const result = await writeJsonAtomic(path, { foo: 'bar' });
+      expect(result.changed).toBe(true);
+      expect(result.dryRun).toBe(false);
+      const content = JSON.parse(await readFile(path, 'utf-8')) as unknown;
+      expect(content).toEqual({ foo: 'bar' });
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('creates a .bak of any pre-existing file before overwriting', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const path = join(dir, 'config.json');
+      await writeFile(path, JSON.stringify({ original: true }));
+
+      await writeJsonAtomic(path, { updated: true });
+
+      const bakContent = JSON.parse(await readFile(path + '.bak', 'utf-8')) as unknown;
+      expect(bakContent).toEqual({ original: true });
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('dry-run reports the change but writes nothing', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const path = join(dir, 'config.json');
+      const result = await writeJsonAtomic(path, { foo: 'bar' }, { dryRun: true });
+
+      expect(result.changed).toBe(true);
+      expect(result.dryRun).toBe(true);
+
+      // File must NOT have been created
+      await expect(stat(path)).rejects.toThrow();
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('is idempotent: mergeAtPath returns changed=false on re-run', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const path = join(dir, '.mcp.json');
+      const entry = { command: 'npx', args: ['-y', 'agent-web-interface@latest'] };
+
+      // First run
+      const existing1 = await readJsonConfig(path);
+      const { merged: merged1, changed: changed1 } = mergeAtPath(
+        existing1,
+        ['mcpServers', 'agent-web-interface'],
+        entry
+      );
+      expect(changed1).toBe(true);
+      await writeJsonAtomic(path, merged1);
+
+      // Second run
+      const existing2 = await readJsonConfig(path);
+      const { changed: changed2 } = mergeAtPath(
+        existing2,
+        ['mcpServers', 'agent-web-interface'],
+        entry
+      );
+      expect(changed2).toBe(false);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+});

--- a/tests/unit/install/harness/claude-code.test.ts
+++ b/tests/unit/install/harness/claude-code.test.ts
@@ -1,19 +1,31 @@
 import { describe, it, expect, vi } from 'vitest';
+import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 import {
-  runClaudeCodeInstall,
+  ClaudeCodeAdapter,
   type CommandRunner,
 } from '../../../../src/install/harness/claude-code.js';
 
-describe('runClaudeCodeInstall', () => {
+async function makeTmpDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'awi-cc-adapter-test-'));
+}
+
+async function cleanup(dir: string): Promise<void> {
+  await rm(dir, { recursive: true, force: true });
+}
+
+describe('ClaudeCodeAdapter.apply()', () => {
   it('invokes claude mcp add with the correct argv', async () => {
     const calls: [string, string[]][] = [];
     const runner: CommandRunner = (cmd, args) => {
       calls.push([cmd, args]);
       return Promise.resolve(0);
     };
+    const adapter = new ClaudeCodeAdapter({ runner });
     const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
 
-    await runClaudeCodeInstall({ runner });
+    const result = await adapter.apply({ scope: 'project' });
 
     expect(calls).toHaveLength(1);
     const [cmd, args] = calls[0];
@@ -26,55 +38,136 @@ describe('runClaudeCodeInstall', () => {
       '-y',
       'agent-web-interface@latest',
     ]);
+    expect(result.changed).toBe(true);
     stderrSpy.mockRestore();
   });
 
-  it('exits non-zero with actionable message when claude is not found (ENOENT)', async () => {
-    const runner: CommandRunner = () => {
-      const err = new Error('spawn claude ENOENT') as NodeJS.ErrnoException;
-      err.code = 'ENOENT';
-      return Promise.reject(err);
-    };
-    const exitSpy = vi.spyOn(process, 'exit').mockReturnValue(undefined as never);
-    const stderrChunks: string[] = [];
-    const stderrSpy = vi
-      .spyOn(process.stderr, 'write')
-      .mockImplementation((chunk: string | Uint8Array) => {
-        stderrChunks.push(typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString());
-        return true;
-      });
-
-    await runClaudeCodeInstall({ runner });
-
-    expect(exitSpy).toHaveBeenCalledWith(1);
-    const stderrOutput = stderrChunks.join('');
-    expect(stderrOutput).toMatch(/claude/i);
-    expect(stderrOutput).toMatch(/not found|not installed|install/i);
-    stderrSpy.mockRestore();
-    exitSpy.mockRestore();
-  });
-
-  it('exits non-zero when claude CLI returns non-zero exit code', async () => {
+  it('throws when claude CLI returns non-zero exit code', async () => {
     const runner: CommandRunner = () => Promise.resolve(2);
-    const exitSpy = vi.spyOn(process, 'exit').mockReturnValue(undefined as never);
-    const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
+    const adapter = new ClaudeCodeAdapter({ runner });
 
-    await runClaudeCodeInstall({ runner });
+    await expect(adapter.apply({ scope: 'project' })).rejects.toThrow(/exit(ed)? with code 2/i);
+  });
 
-    expect(exitSpy).toHaveBeenCalledWith(2);
-    stderrSpy.mockRestore();
-    exitSpy.mockRestore();
+  it('falls back to .mcp.json when claude CLI is not found (ENOENT)', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const runner: CommandRunner = () => {
+        const err = new Error('spawn claude ENOENT') as NodeJS.ErrnoException;
+        err.code = 'ENOENT';
+        return Promise.reject(err);
+      };
+      const adapter = new ClaudeCodeAdapter({ runner });
+
+      const result = await adapter.apply({ scope: 'project', cwd: dir });
+
+      expect(result.changed).toBe(true);
+      expect(result.dryRun).toBe(false);
+
+      const mcpJson = JSON.parse(await readFile(join(dir, '.mcp.json'), 'utf-8')) as {
+        mcpServers: Record<string, { command: string; args: string[] }>;
+      };
+      expect(mcpJson.mcpServers['agent-web-interface']).toEqual({
+        command: 'npx',
+        args: ['-y', 'agent-web-interface@latest'],
+      });
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('fallback preserves unrelated keys in .mcp.json', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const runner: CommandRunner = () => {
+        const err = new Error('ENOENT') as NodeJS.ErrnoException;
+        err.code = 'ENOENT';
+        return Promise.reject(err);
+      };
+      const adapter = new ClaudeCodeAdapter({ runner });
+
+      // Pre-populate with another server
+      const existing = { mcpServers: { other: { command: 'other', args: [] } } };
+      const { writeFile } = await import('node:fs/promises');
+      await writeFile(join(dir, '.mcp.json'), JSON.stringify(existing));
+
+      await adapter.apply({ scope: 'project', cwd: dir });
+
+      const mcpJson = JSON.parse(await readFile(join(dir, '.mcp.json'), 'utf-8')) as {
+        mcpServers: Record<string, unknown>;
+      };
+      expect(mcpJson.mcpServers.other).toEqual({ command: 'other', args: [] });
+      expect(mcpJson.mcpServers['agent-web-interface']).toBeTruthy();
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('fallback is idempotent: second apply returns changed=false', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const runner: CommandRunner = () => {
+        const err = new Error('ENOENT') as NodeJS.ErrnoException;
+        err.code = 'ENOENT';
+        return Promise.reject(err);
+      };
+      const adapter = new ClaudeCodeAdapter({ runner });
+
+      await adapter.apply({ scope: 'project', cwd: dir });
+      const second = await adapter.apply({ scope: 'project', cwd: dir });
+
+      expect(second.changed).toBe(false);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('fallback respects --dry-run: writes nothing', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const runner: CommandRunner = () => {
+        const err = new Error('ENOENT') as NodeJS.ErrnoException;
+        err.code = 'ENOENT';
+        return Promise.reject(err);
+      };
+      const adapter = new ClaudeCodeAdapter({ runner });
+
+      const result = await adapter.apply({ scope: 'project', cwd: dir, dryRun: true });
+
+      expect(result.dryRun).toBe(true);
+      const { stat } = await import('node:fs/promises');
+      await expect(stat(join(dir, '.mcp.json'))).rejects.toThrow();
+    } finally {
+      await cleanup(dir);
+    }
   });
 
   it('does not write to stdout', async () => {
     const runner: CommandRunner = () => Promise.resolve(0);
+    const adapter = new ClaudeCodeAdapter({ runner });
     const stdoutSpy = vi.spyOn(process.stdout, 'write').mockReturnValue(true);
     const stderrSpy = vi.spyOn(process.stderr, 'write').mockReturnValue(true);
 
-    await runClaudeCodeInstall({ runner });
+    await adapter.apply({ scope: 'project' });
 
     expect(stdoutSpy).not.toHaveBeenCalled();
     stdoutSpy.mockRestore();
     stderrSpy.mockRestore();
+  });
+});
+
+describe('ClaudeCodeAdapter meta', () => {
+  it('has correct id and label', () => {
+    const adapter = new ClaudeCodeAdapter();
+    expect(adapter.id).toBe('claude-code');
+    expect(adapter.label).toBe('Claude Code');
+    expect(adapter.supportsSkill).toBe(true);
+    expect(adapter.scopes).toContain('project');
+  });
+
+  it('carries the resolved server command', () => {
+    const adapter = new ClaudeCodeAdapter();
+    expect(adapter.serverCommand.command).toBe('npx');
+    expect(adapter.serverCommand.args).toContain('agent-web-interface@latest');
   });
 });


### PR DESCRIPTION
Closes #66

## Summary

- **`config-io`**: `mergeAtPath` (non-clobbering nested merge), `readJsonConfig` (returns `{}` on missing), `writeJsonAtomic` (backup→temp→rename, `.bak`, dry-run mode)
- **`HarnessAdapter`** interface: `id`, `label`, `supportsSkill`, `scopes`, `serverCommand` + `detect()`, `apply()`, `status()` — all later adapters implement this
- **`ClaudeCodeAdapter`** refactored: tries `claude mcp add` first; when `claude` CLI is absent (ENOENT), falls back to writing `.mcp.json` via `config-io`
- `runInstall` wired to `adapter.apply()` with `--dry-run` passthrough; adapter never calls `process.exit()` — only `runInstall` does on error

## Test plan
- [x] `mergeAtPath`: nested insert, unchanged=false, intermediate keys
- [x] `writeJsonAtomic`: new file, `.bak` backup, dry-run no-write, atomic rename
- [x] Idempotency: second run returns `changed=false`
- [x] CC adapter: `claude mcp add` argv, non-zero throws, ENOENT fallback, sibling key preservation, dry-run, stdout cleanliness
- [x] All 1767 tests pass (`npm run check` green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)