### PR TITLE
feat: Cursor adapter (MCP + .mdc rule) [#71]

### DIFF
--- a/src/install/harness/cursor.ts
+++ b/src/install/harness/cursor.ts
@@ -1,0 +1,114 @@
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import type {
+  HarnessAdapter,
+  ApplyOpts,
+  ApplyResult,
+  StatusOpts,
+  HarnessStatus,
+  ServerCommand,
+} from '../harness-adapter.js';
+import { readJsonConfig, mergeAtPath, writeJsonAtomic, writeFileAtomic } from '../config-io.js';
+import type { SkillContent } from '../skill-source.js';
+import { resolveSkill } from '../skill-source.js';
+
+export type SkillResolver = () => Promise<SkillContent>;
+
+export interface CursorAdapterDeps {
+  skillResolver?: SkillResolver;
+}
+
+const SERVER_NAME = 'agent-web-interface';
+
+const SERVER_COMMAND: ServerCommand = {
+  command: 'npx',
+  args: ['-y', 'agent-web-interface@latest'],
+};
+
+function mcpJsonPath(scope: 'project' | 'user' | 'global', cwd: string, homeDir: string): string {
+  if (scope === 'user' || scope === 'global') {
+    return join(homeDir, '.cursor', 'mcp.json');
+  }
+  return join(cwd, '.cursor', 'mcp.json');
+}
+
+function buildMdcContent(meta: SkillContent['meta'], body: string): string {
+  return `---\ndescription: ${meta.description}\nalwaysApply: false\n---\n${body}`;
+}
+
+export class CursorAdapter implements HarnessAdapter {
+  readonly id = 'cursor';
+  readonly label = 'Cursor';
+  readonly supportsSkill = true;
+  readonly scopes = ['project', 'user'] as const;
+  readonly serverCommand = SERVER_COMMAND;
+
+  private readonly resolveSkillFn: SkillResolver;
+
+  constructor(deps?: CursorAdapterDeps) {
+    this.resolveSkillFn = deps?.skillResolver ?? (() => resolveSkill());
+  }
+
+  async detect(): Promise<boolean> {
+    try {
+      const { access } = await import('node:fs/promises');
+      await access(join(homedir(), '.cursor'));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async apply(opts: ApplyOpts): Promise<ApplyResult> {
+    const { scope, dryRun = false, cwd = process.cwd(), homeDir = homedir() } = opts;
+
+    const configPath = mcpJsonPath(scope, cwd, homeDir);
+    const existing = await readJsonConfig(configPath);
+    const { merged, changed } = mergeAtPath(existing, ['mcpServers', SERVER_NAME], {
+      command: SERVER_COMMAND.command,
+      args: SERVER_COMMAND.args,
+    });
+
+    if (!changed) {
+      return {
+        changed: false,
+        dryRun,
+        message: 'Already configured in .cursor/mcp.json (no changes needed)',
+      };
+    }
+
+    const writeResult = await writeJsonAtomic(configPath, merged, { dryRun });
+    await this.placeSkill(cwd, dryRun);
+
+    return {
+      changed: writeResult.changed,
+      dryRun: writeResult.dryRun,
+      message: dryRun
+        ? 'Would write .cursor/mcp.json (--dry-run)'
+        : '✓ Registered in Cursor via .cursor/mcp.json',
+    };
+  }
+
+  private async placeSkill(cwd: string, dryRun: boolean): Promise<void> {
+    try {
+      const skill = await this.resolveSkillFn();
+      const rulePath = join(cwd, '.cursor', 'rules', `${SERVER_NAME}.mdc`);
+      const content = buildMdcContent(skill.meta, skill.body);
+      await writeFileAtomic(rulePath, content, { dryRun });
+    } catch {
+      // Skill placement is best-effort; never fails install
+    }
+  }
+
+  async status(opts: StatusOpts): Promise<HarnessStatus> {
+    const { scope, cwd = process.cwd(), homeDir = homedir() } = opts;
+    const configPath = mcpJsonPath(scope, cwd, homeDir);
+    const existing = await readJsonConfig(configPath);
+    const mcpServers = existing.mcpServers as Record<string, unknown> | undefined;
+    const configured = mcpServers?.[SERVER_NAME] != null;
+    return {
+      configured,
+      message: configured ? 'Configured in .cursor/mcp.json' : 'Not configured in .cursor/mcp.json',
+    };
+  }
+}

--- a/src/install/index.ts
+++ b/src/install/index.ts
@@ -1,4 +1,5 @@
 import { ClaudeCodeAdapter, type CommandRunner } from './harness/claude-code.js';
+import { CursorAdapter } from './harness/cursor.js';
 
 export type { CommandRunner };
 
@@ -6,7 +7,7 @@ export interface InstallDeps {
   claudeCodeRunner?: CommandRunner;
 }
 
-const SUPPORTED_HARNESSES = ['claude-code'] as const;
+const SUPPORTED_HARNESSES = ['claude-code', 'cursor'] as const;
 type SupportedHarness = (typeof SUPPORTED_HARNESSES)[number];
 
 function parseHarness(argv: string[]): SupportedHarness | undefined {
@@ -37,6 +38,12 @@ export async function runInstall(argv: string[], deps?: InstallDeps): Promise<vo
     switch (harness) {
       case 'claude-code': {
         const adapter = new ClaudeCodeAdapter({ runner: deps?.claudeCodeRunner });
+        const result = await adapter.apply({ scope: 'project', dryRun });
+        message = result.message;
+        break;
+      }
+      case 'cursor': {
+        const adapter = new CursorAdapter();
         const result = await adapter.apply({ scope: 'project', dryRun });
         message = result.message;
         break;

--- a/src/install/skill-source.ts
+++ b/src/install/skill-source.ts
@@ -9,6 +9,7 @@ export interface SkillMeta {
 export interface SkillContent {
   meta: SkillMeta;
   rawContent: string;
+  body: string;
 }
 
 const PACKAGE_NAME = 'agent-web-interface';
@@ -37,6 +38,11 @@ async function findPackageRoot(startDir: string): Promise<string> {
     `Could not find ${PACKAGE_NAME} package root from "${startDir}". ` +
       `Is the package installed correctly?`
   );
+}
+
+function stripFrontmatter(content: string): string {
+  const match = /^---\n[\s\S]*?---\n/.exec(content);
+  return match ? content.slice(match[0].length) : content;
 }
 
 function parseFrontmatter(content: string): SkillMeta {
@@ -71,5 +77,6 @@ export async function resolveSkill(fromDir?: string): Promise<SkillContent> {
   const skillPath = join(pkgRoot, SKILL_REL_PATH);
   const rawContent = await readFile(skillPath, 'utf-8');
   const meta = parseFrontmatter(rawContent);
-  return { meta, rawContent };
+  const body = stripFrontmatter(rawContent);
+  return { meta, rawContent, body };
 }

--- a/tests/unit/install/harness/cursor.test.ts
+++ b/tests/unit/install/harness/cursor.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm, readFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { CursorAdapter, type SkillResolver } from '../../../../src/install/harness/cursor.js';
+
+async function makeTmpDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'awi-cursor-adapter-test-'));
+}
+
+async function cleanup(dir: string): Promise<void> {
+  await rm(dir, { recursive: true, force: true });
+}
+
+const FAKE_SKILL_BODY = '# Agent Web Interface Guide\n\nFake skill body content.\n';
+
+const FAKE_SKILL_META = {
+  name: 'agent-web-interface',
+  description: 'Drive a real browser against a live or staging website.',
+};
+
+function makeSkillResolver(): SkillResolver {
+  return () =>
+    Promise.resolve({
+      meta: FAKE_SKILL_META,
+      rawContent: `---\nname: agent-web-interface\ndescription: Drive a real browser against a live or staging website.\n---\n${FAKE_SKILL_BODY}`,
+      body: FAKE_SKILL_BODY,
+    });
+}
+
+describe('CursorAdapter.apply() — project scope', () => {
+  it('writes .cursor/mcp.json with mcpServers entry', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const adapter = new CursorAdapter({ skillResolver: makeSkillResolver() });
+      const result = await adapter.apply({ scope: 'project', cwd: dir });
+
+      expect(result.changed).toBe(true);
+      expect(result.dryRun).toBe(false);
+
+      const mcpJson = JSON.parse(await readFile(join(dir, '.cursor', 'mcp.json'), 'utf-8')) as {
+        mcpServers: Record<string, { command: string; args: string[] }>;
+      };
+      expect(mcpJson.mcpServers['agent-web-interface']).toEqual({
+        command: 'npx',
+        args: ['-y', 'agent-web-interface@latest'],
+      });
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('preserves unrelated mcpServers entries in .cursor/mcp.json', async () => {
+    const dir = await makeTmpDir();
+    try {
+      // Pre-seed the config
+      const { mkdir, writeFile } = await import('node:fs/promises');
+      await mkdir(join(dir, '.cursor'), { recursive: true });
+      await writeFile(
+        join(dir, '.cursor', 'mcp.json'),
+        JSON.stringify({
+          mcpServers: {
+            'other-server': { command: 'node', args: ['other.js'] },
+          },
+        })
+      );
+
+      const adapter = new CursorAdapter({ skillResolver: makeSkillResolver() });
+      await adapter.apply({ scope: 'project', cwd: dir });
+
+      const mcpJson = JSON.parse(await readFile(join(dir, '.cursor', 'mcp.json'), 'utf-8')) as {
+        mcpServers: Record<string, unknown>;
+      };
+      expect(mcpJson.mcpServers['other-server']).toEqual({ command: 'node', args: ['other.js'] });
+      expect(mcpJson.mcpServers['agent-web-interface']).toBeDefined();
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('is idempotent — returns changed=false on second apply', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const adapter = new CursorAdapter({ skillResolver: makeSkillResolver() });
+      await adapter.apply({ scope: 'project', cwd: dir });
+      const result2 = await adapter.apply({ scope: 'project', cwd: dir });
+      expect(result2.changed).toBe(false);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('dry-run returns changed=true without writing files', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const adapter = new CursorAdapter({ skillResolver: makeSkillResolver() });
+      const result = await adapter.apply({ scope: 'project', cwd: dir, dryRun: true });
+
+      expect(result.changed).toBe(true);
+      expect(result.dryRun).toBe(true);
+
+      // File should NOT have been written
+      const { access } = await import('node:fs/promises');
+      await expect(access(join(dir, '.cursor', 'mcp.json'))).rejects.toThrow();
+    } finally {
+      await cleanup(dir);
+    }
+  });
+});
+
+describe('CursorAdapter.apply() — skill placement', () => {
+  it('writes .cursor/rules/agent-web-interface.mdc with correct frontmatter + body', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const adapter = new CursorAdapter({ skillResolver: makeSkillResolver() });
+      await adapter.apply({ scope: 'project', cwd: dir });
+
+      const mdcContent = await readFile(
+        join(dir, '.cursor', 'rules', 'agent-web-interface.mdc'),
+        'utf-8'
+      );
+      expect(mdcContent).toContain('---');
+      expect(mdcContent).toContain('description:');
+      expect(mdcContent).toContain(FAKE_SKILL_META.description);
+      expect(mdcContent).toContain('alwaysApply: false');
+      expect(mdcContent).toContain(FAKE_SKILL_BODY);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('mdc frontmatter does NOT contain nested YAML from rawContent', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const adapter = new CursorAdapter({ skillResolver: makeSkillResolver() });
+      await adapter.apply({ scope: 'project', cwd: dir });
+
+      const mdcContent = await readFile(
+        join(dir, '.cursor', 'rules', 'agent-web-interface.mdc'),
+        'utf-8'
+      );
+      // The only frontmatter block should be the wrapper, not the skill's own frontmatter
+      const frontmatterMatches = mdcContent.match(/^---$/gm);
+      expect(frontmatterMatches).toHaveLength(2); // opening and closing ---
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('skill placement failure does not prevent MCP registration', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const failingResolver: SkillResolver = () => Promise.reject(new Error('skill not found'));
+      const adapter = new CursorAdapter({ skillResolver: failingResolver });
+      const result = await adapter.apply({ scope: 'project', cwd: dir });
+
+      // MCP registration should still succeed
+      expect(result.changed).toBe(true);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+});
+
+describe('CursorAdapter.apply() — user scope', () => {
+  it('writes to homeDir/.cursor/mcp.json for user scope', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const adapter = new CursorAdapter({ skillResolver: makeSkillResolver() });
+      const result = await adapter.apply({ scope: 'user', homeDir: dir, cwd: dir });
+
+      expect(result.changed).toBe(true);
+
+      const mcpJson = JSON.parse(await readFile(join(dir, '.cursor', 'mcp.json'), 'utf-8')) as {
+        mcpServers: Record<string, unknown>;
+      };
+      expect(mcpJson.mcpServers['agent-web-interface']).toBeDefined();
+    } finally {
+      await cleanup(dir);
+    }
+  });
+});
+
+describe('CursorAdapter.status()', () => {
+  it('returns configured=false when .cursor/mcp.json does not exist', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const adapter = new CursorAdapter({ skillResolver: makeSkillResolver() });
+      const status = await adapter.status({ scope: 'project', cwd: dir });
+      expect(status.configured).toBe(false);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('returns configured=true when agent-web-interface is in .cursor/mcp.json', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const adapter = new CursorAdapter({ skillResolver: makeSkillResolver() });
+      await adapter.apply({ scope: 'project', cwd: dir });
+      const status = await adapter.status({ scope: 'project', cwd: dir });
+      expect(status.configured).toBe(true);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+});
+
+describe('CursorAdapter metadata', () => {
+  it('has correct id and label', () => {
+    const adapter = new CursorAdapter({ skillResolver: makeSkillResolver() });
+    expect(adapter.id).toBe('cursor');
+    expect(adapter.label).toBe('Cursor');
+  });
+
+  it('supportsSkill is true', () => {
+    const adapter = new CursorAdapter({ skillResolver: makeSkillResolver() });
+    expect(adapter.supportsSkill).toBe(true);
+  });
+
+  it('scopes includes project and user', () => {
+    const adapter = new CursorAdapter({ skillResolver: makeSkillResolver() });
+    expect(adapter.scopes).toContain('project');
+    expect(adapter.scopes).toContain('user');
+  });
+});


### PR DESCRIPTION
## Summary

- `CursorAdapter` implements `HarnessAdapter`: merges the server into `.cursor/mcp.json` (project) or `~/.cursor/mcp.json` (user) under `mcpServers`, preserving other entries via `config-io`
- Writes `.cursor/rules/agent-web-interface.mdc` with `description` + `alwaysApply: false` frontmatter and the canonical skill body (frontmatter-stripped via new `body` field on `SkillContent`)
- Skill placement is best-effort — a resolver failure never blocks MCP registration
- `SUPPORTED_HARNESSES` extended to include `'cursor'`
- `SkillContent` gains `body: string` (content after stripping YAML frontmatter) — enables Cursor/VS Code adapters to write native-format files without nested frontmatter

## Test plan

- [x] `npm run check` green — 83 test files, 1788 tests
- [x] 13 unit tests covering: MCP merge, unrelated-key preservation, idempotency (changed=false on 2nd apply), dry-run (changed=true but no disk write), skill `.mdc` frontmatter structure (exactly 2 `---` delimiters), skill body content, best-effort resolver failure, user-scope path, status configured/unconfigured

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)