### PR TITLE
feat: VS Code adapter (servers/type:stdio + Copilot instructions) [#72]

### DIFF
--- a/src/install/harness/vscode.ts
+++ b/src/install/harness/vscode.ts
@@ -1,0 +1,114 @@
+import { join } from 'node:path';
+import type {
+  HarnessAdapter,
+  ApplyOpts,
+  ApplyResult,
+  StatusOpts,
+  HarnessStatus,
+  ServerCommand,
+} from '../harness-adapter.js';
+import { readJsonConfig, mergeAtPath, writeJsonAtomic, writeFileAtomic } from '../config-io.js';
+import type { SkillContent } from '../skill-source.js';
+import { resolveSkill } from '../skill-source.js';
+
+export type SkillResolver = () => Promise<SkillContent>;
+
+export interface VSCodeAdapterDeps {
+  skillResolver?: SkillResolver;
+}
+
+const SERVER_NAME = 'agent-web-interface';
+
+// VS Code uses `servers` key + `type: "stdio"` (not `mcpServers`)
+const SERVER_COMMAND: ServerCommand = {
+  command: 'npx',
+  args: ['-y', 'agent-web-interface@latest'],
+};
+
+const VSCODE_SERVER_ENTRY = {
+  type: 'stdio',
+  command: SERVER_COMMAND.command,
+  args: SERVER_COMMAND.args,
+};
+
+function buildInstructionsContent(body: string): string {
+  return `---\napplyTo: "**"\n---\n${body}`;
+}
+
+export class VSCodeAdapter implements HarnessAdapter {
+  readonly id = 'vscode';
+  readonly label = 'VS Code';
+  readonly supportsSkill = true;
+  readonly scopes = ['project'] as const;
+  readonly serverCommand = SERVER_COMMAND;
+
+  private readonly resolveSkillFn: SkillResolver;
+
+  constructor(deps?: VSCodeAdapterDeps) {
+    this.resolveSkillFn = deps?.skillResolver ?? (() => resolveSkill());
+  }
+
+  async detect(): Promise<boolean> {
+    try {
+      const { access } = await import('node:fs/promises');
+      await access(join(process.cwd(), '.vscode'));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async apply(opts: ApplyOpts): Promise<ApplyResult> {
+    const { dryRun = false, cwd = process.cwd() } = opts;
+
+    const configPath = join(cwd, '.vscode', 'mcp.json');
+    const existing = await readJsonConfig(configPath);
+    const { merged, changed } = mergeAtPath(
+      existing,
+      ['servers', SERVER_NAME],
+      VSCODE_SERVER_ENTRY
+    );
+
+    if (!changed) {
+      return {
+        changed: false,
+        dryRun,
+        message: 'Already configured in .vscode/mcp.json (no changes needed)',
+      };
+    }
+
+    const writeResult = await writeJsonAtomic(configPath, merged, { dryRun });
+    await this.placeSkill(cwd, dryRun);
+
+    return {
+      changed: writeResult.changed,
+      dryRun: writeResult.dryRun,
+      message: dryRun
+        ? 'Would write .vscode/mcp.json (--dry-run)'
+        : '✓ Registered in VS Code via .vscode/mcp.json',
+    };
+  }
+
+  private async placeSkill(cwd: string, dryRun: boolean): Promise<void> {
+    try {
+      const skill = await this.resolveSkillFn();
+      const instrPath = join(cwd, '.github', 'instructions', `${SERVER_NAME}.instructions.md`);
+      const content = buildInstructionsContent(skill.body);
+      await writeFileAtomic(instrPath, content, { dryRun });
+    } catch {
+      // Skill placement is best-effort; never fails install
+    }
+  }
+
+  async status(opts: StatusOpts): Promise<HarnessStatus> {
+    const { cwd = process.cwd() } = opts;
+    const configPath = join(cwd, '.vscode', 'mcp.json');
+    const existing = await readJsonConfig(configPath);
+    const servers = existing.servers as Record<string, unknown> | undefined;
+    const configured = servers?.[SERVER_NAME] != null;
+    return {
+      configured,
+      message: configured ? 'Configured in .vscode/mcp.json' : 'Not configured in .vscode/mcp.json',
+    };
+  }
+}

--- a/src/install/index.ts
+++ b/src/install/index.ts
@@ -1,5 +1,6 @@
 import { ClaudeCodeAdapter, type CommandRunner } from './harness/claude-code.js';
 import { CursorAdapter } from './harness/cursor.js';
+import { VSCodeAdapter } from './harness/vscode.js';
 
 export type { CommandRunner };
 
@@ -7,7 +8,7 @@ export interface InstallDeps {
   claudeCodeRunner?: CommandRunner;
 }
 
-const SUPPORTED_HARNESSES = ['claude-code', 'cursor'] as const;
+const SUPPORTED_HARNESSES = ['claude-code', 'cursor', 'vscode'] as const;
 type SupportedHarness = (typeof SUPPORTED_HARNESSES)[number];
 
 function parseHarness(argv: string[]): SupportedHarness | undefined {
@@ -44,6 +45,12 @@ export async function runInstall(argv: string[], deps?: InstallDeps): Promise<vo
       }
       case 'cursor': {
         const adapter = new CursorAdapter();
+        const result = await adapter.apply({ scope: 'project', dryRun });
+        message = result.message;
+        break;
+      }
+      case 'vscode': {
+        const adapter = new VSCodeAdapter();
         const result = await adapter.apply({ scope: 'project', dryRun });
         message = result.message;
         break;

--- a/tests/unit/install/harness/vscode.test.ts
+++ b/tests/unit/install/harness/vscode.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtemp, rm, readFile, mkdir, writeFile } from 'node:fs/promises';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import { VSCodeAdapter, type SkillResolver } from '../../../../src/install/harness/vscode.js';
+
+async function makeTmpDir(): Promise<string> {
+  return mkdtemp(join(tmpdir(), 'awi-vscode-adapter-test-'));
+}
+
+async function cleanup(dir: string): Promise<void> {
+  await rm(dir, { recursive: true, force: true });
+}
+
+const FAKE_SKILL_BODY = '# Agent Web Interface Guide\n\nFake skill body content.\n';
+
+const FAKE_SKILL_META = {
+  name: 'agent-web-interface',
+  description: 'Drive a real browser against a live or staging website.',
+};
+
+function makeSkillResolver(): SkillResolver {
+  return () =>
+    Promise.resolve({
+      meta: FAKE_SKILL_META,
+      rawContent: `---\nname: agent-web-interface\ndescription: ${FAKE_SKILL_META.description}\n---\n${FAKE_SKILL_BODY}`,
+      body: FAKE_SKILL_BODY,
+    });
+}
+
+describe('VSCodeAdapter.apply() — MCP registration', () => {
+  it('writes .vscode/mcp.json using the servers key (not mcpServers)', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const adapter = new VSCodeAdapter({ skillResolver: makeSkillResolver() });
+      const result = await adapter.apply({ scope: 'project', cwd: dir });
+
+      expect(result.changed).toBe(true);
+
+      const raw = JSON.parse(await readFile(join(dir, '.vscode', 'mcp.json'), 'utf-8')) as Record<
+        string,
+        unknown
+      >;
+      expect(raw.mcpServers).toBeUndefined();
+      expect(raw.servers).toBeDefined();
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('server entry has type: "stdio"', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const adapter = new VSCodeAdapter({ skillResolver: makeSkillResolver() });
+      await adapter.apply({ scope: 'project', cwd: dir });
+
+      const raw = JSON.parse(await readFile(join(dir, '.vscode', 'mcp.json'), 'utf-8')) as {
+        servers: Record<string, { type: string; command: string; args: string[] }>;
+      };
+      const entry = raw.servers['agent-web-interface'];
+      expect(entry).toBeDefined();
+      expect(entry.type).toBe('stdio');
+      expect(entry.command).toBe('npx');
+      expect(entry.args).toEqual(['-y', 'agent-web-interface@latest']);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('preserves unrelated servers entries', async () => {
+    const dir = await makeTmpDir();
+    try {
+      await mkdir(join(dir, '.vscode'), { recursive: true });
+      await writeFile(
+        join(dir, '.vscode', 'mcp.json'),
+        JSON.stringify({
+          servers: {
+            'other-server': { type: 'stdio', command: 'node', args: ['other.js'] },
+          },
+        })
+      );
+
+      const adapter = new VSCodeAdapter({ skillResolver: makeSkillResolver() });
+      await adapter.apply({ scope: 'project', cwd: dir });
+
+      const raw = JSON.parse(await readFile(join(dir, '.vscode', 'mcp.json'), 'utf-8')) as {
+        servers: Record<string, unknown>;
+      };
+      expect(raw.servers['other-server']).toEqual({
+        type: 'stdio',
+        command: 'node',
+        args: ['other.js'],
+      });
+      expect(raw.servers['agent-web-interface']).toBeDefined();
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('is idempotent — returns changed=false on second apply', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const adapter = new VSCodeAdapter({ skillResolver: makeSkillResolver() });
+      await adapter.apply({ scope: 'project', cwd: dir });
+      const result2 = await adapter.apply({ scope: 'project', cwd: dir });
+      expect(result2.changed).toBe(false);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('dry-run returns changed=true without writing files', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const adapter = new VSCodeAdapter({ skillResolver: makeSkillResolver() });
+      const result = await adapter.apply({ scope: 'project', cwd: dir, dryRun: true });
+
+      expect(result.changed).toBe(true);
+      expect(result.dryRun).toBe(true);
+
+      const { access } = await import('node:fs/promises');
+      await expect(access(join(dir, '.vscode', 'mcp.json'))).rejects.toThrow();
+    } finally {
+      await cleanup(dir);
+    }
+  });
+});
+
+describe('VSCodeAdapter.apply() — skill placement', () => {
+  it('writes .github/instructions/agent-web-interface.instructions.md', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const adapter = new VSCodeAdapter({ skillResolver: makeSkillResolver() });
+      await adapter.apply({ scope: 'project', cwd: dir });
+
+      const instrContent = await readFile(
+        join(dir, '.github', 'instructions', 'agent-web-interface.instructions.md'),
+        'utf-8'
+      );
+      expect(instrContent).toContain('applyTo:');
+      expect(instrContent).toContain('"**"');
+      expect(instrContent).toContain(FAKE_SKILL_BODY);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('instructions file does NOT clobber .github/copilot-instructions.md', async () => {
+    const dir = await makeTmpDir();
+    try {
+      await mkdir(join(dir, '.github'), { recursive: true });
+      const copilotContent = '# My existing copilot instructions\n\nDo not overwrite me.\n';
+      await writeFile(join(dir, '.github', 'copilot-instructions.md'), copilotContent);
+
+      const adapter = new VSCodeAdapter({ skillResolver: makeSkillResolver() });
+      await adapter.apply({ scope: 'project', cwd: dir });
+
+      // copilot-instructions.md should be unchanged
+      const after = await readFile(join(dir, '.github', 'copilot-instructions.md'), 'utf-8');
+      expect(after).toBe(copilotContent);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('instructions frontmatter has exactly 2 --- delimiters', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const adapter = new VSCodeAdapter({ skillResolver: makeSkillResolver() });
+      await adapter.apply({ scope: 'project', cwd: dir });
+
+      const instrContent = await readFile(
+        join(dir, '.github', 'instructions', 'agent-web-interface.instructions.md'),
+        'utf-8'
+      );
+      const frontmatterMatches = instrContent.match(/^---$/gm);
+      expect(frontmatterMatches).toHaveLength(2);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('skill placement failure does not prevent MCP registration', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const failingResolver: SkillResolver = () => Promise.reject(new Error('skill not found'));
+      const adapter = new VSCodeAdapter({ skillResolver: failingResolver });
+      const result = await adapter.apply({ scope: 'project', cwd: dir });
+
+      expect(result.changed).toBe(true);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+});
+
+describe('VSCodeAdapter.status()', () => {
+  it('returns configured=false when .vscode/mcp.json does not exist', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const adapter = new VSCodeAdapter({ skillResolver: makeSkillResolver() });
+      const status = await adapter.status({ scope: 'project', cwd: dir });
+      expect(status.configured).toBe(false);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('returns configured=true when agent-web-interface is in .vscode/mcp.json', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const adapter = new VSCodeAdapter({ skillResolver: makeSkillResolver() });
+      await adapter.apply({ scope: 'project', cwd: dir });
+      const status = await adapter.status({ scope: 'project', cwd: dir });
+      expect(status.configured).toBe(true);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+});
+
+describe('VSCodeAdapter metadata', () => {
+  it('has correct id and label', () => {
+    const adapter = new VSCodeAdapter({ skillResolver: makeSkillResolver() });
+    expect(adapter.id).toBe('vscode');
+    expect(adapter.label).toBe('VS Code');
+  });
+
+  it('supportsSkill is true', () => {
+    const adapter = new VSCodeAdapter({ skillResolver: makeSkillResolver() });
+    expect(adapter.supportsSkill).toBe(true);
+  });
+
+  it('scopes includes project', () => {
+    const adapter = new VSCodeAdapter({ skillResolver: makeSkillResolver() });
+    expect(adapter.scopes).toContain('project');
+  });
+});


### PR DESCRIPTION
## Summary

- `VSCodeAdapter` implements `HarnessAdapter` using VS Code's own MCP schema: `.vscode/mcp.json` with `servers` key (not `mcpServers`) and `type: "stdio"` on each server entry
- Writes `.github/instructions/agent-web-interface.instructions.md` with `applyTo: "**"` frontmatter and canonical skill body (frontmatter-stripped)
- Explicitly does **not** touch `.github/copilot-instructions.md` — verified by test
- Skill placement is best-effort: resolver failure never blocks MCP registration
- `SUPPORTED_HARNESSES` extended to include `'vscode'`

## Schema verification note

VS Code's MCP config shape (`servers` + `type:"stdio"`) is confirmed by the [VS Code MCP docs](https://code.visualstudio.com/docs/copilot/chat/mcp-servers) and their official JSON schema. The schema differs from Claude Desktop / Cursor (which use `mcpServers` without `type`).

## Test plan

- [x] `npm run check` green — 84 test files, 1802 tests
- [x] 14 unit tests covering: `servers` key present (not `mcpServers`), `type: "stdio"` on entry, unrelated-key preservation, idempotency, dry-run, instructions frontmatter (exactly 2 `---`), instructions body content, copilot-instructions.md no-clobber, best-effort resolver failure, status configured/unconfigured

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)