### PR TITLE
docs: README quickstart leads with install command + CHANGELOG (#73)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,18 @@
+## [Unreleased]
+
+### Added
+
+- `agent-web-interface install` — interactive installer that auto-detects Claude Code, Cursor, VS Code, and Claude Desktop; registers the MCP server and places the agent skill in one step
+- `agent-web-interface doctor` — read-only status command showing per-harness MCP and skill installation state
+- Install flags: `--harness` (id, `all`, or comma-separated), `--scope project|user`, `--global`, `--project`, `--browser-mode`, `--headless`, `--cdp-url`, `--pin`, `--dry-run`, `--yes`
+- Cursor adapter: merges `mcpServers` into `.cursor/mcp.json` and places skill as `.cursor/rules/agent-web-interface.mdc`
+- VS Code adapter: merges into `.vscode/mcp.json` under `servers` key (`type: "stdio"`); places skill as `.github/instructions/agent-web-interface.instructions.md`
+- Claude Desktop adapter: always global, MCP-only (no skill placement), resolves OS-specific config path for macOS, Linux, and Windows
+- `skills-lock.json` SHA-256 hash verification for skill integrity
+- `--help` now documents all install flags and the `doctor` command
+
+---
+
 ## [4.6.2] - 2026-06-07
 
 - refactor: rename skill agent-web-interface-guide -> agent-web-interface

--- a/README.md
+++ b/README.md
@@ -609,69 +609,97 @@ Agent Web Interface exposes MCP tools across the main phases of browser use.
 
 ## Quickstart
 
-### Claude Code
+Run the interactive installer — it auto-detects which AI tools you have installed and registers the MCP server and agent skill in one step:
 
 ```bash
-claude mcp add agent-web-interface -- npx agent-web-interface@latest
+npx agent-web-interface install
 ```
 
-Then ask Claude Code to use the browser:
+Then ask your AI to use the browser:
 
 ```text
 Open https://example.com and summarize the main actions available to a user.
 ```
 
-### Install the agent skill (recommended)
+### Target a specific harness
 
-The [`agent-web-interface`](skills/agent-web-interface/SKILL.md) skill teaches the agent how to drive these tools well — structured page snapshots, stable element IDs, form inspection, and reliable Playwright selector capture. Install it with [`npx skills`](https://github.com/vercel-labs/skills):
+```bash
+# Claude Code (also installs the agent skill)
+npx agent-web-interface install --harness claude-code
+
+# Cursor
+npx agent-web-interface install --harness cursor
+
+# VS Code
+npx agent-web-interface install --harness vscode
+
+# Claude Desktop (MCP only — no skill placement)
+npx agent-web-interface install --harness claude-desktop
+
+# Multiple at once
+npx agent-web-interface install --harness cursor,vscode
+
+# All detected harnesses
+npx agent-web-interface install --harness all
+```
+
+### Install flags
+
+| Flag                       | Description                                                                                        |
+| -------------------------- | -------------------------------------------------------------------------------------------------- |
+| `--harness <id\|all\|csv>` | Target harness(es): `claude-code`, `cursor`, `vscode`, `claude-desktop`, `all`, or comma-separated |
+| `--scope project\|user`    | Where to write the config (default: `project`)                                                     |
+| `--global`                 | Alias for `--scope global`                                                                         |
+| `--project`                | Alias for `--scope project`                                                                        |
+| `--browser-mode <mode>`    | Browser mode: `auto` (default), `user`, `persistent`, `isolated`                                   |
+| `--headless`               | Launch Chrome in headless mode                                                                     |
+| `--cdp-url <url>`          | Connect to an existing Chrome DevTools Protocol endpoint                                           |
+| `--pin <version>`          | Register an exact version instead of `@latest`                                                     |
+| `--dry-run`                | Preview changes without writing files                                                              |
+| `--yes`                    | Skip interactive prompts (non-TTY mode)                                                            |
+
+### Check installation status
+
+```bash
+npx agent-web-interface doctor
+```
+
+Prints a per-harness status table showing whether the MCP server is registered and whether the agent skill is installed.
+
+### Skill-only installation (advanced)
+
+The [`agent-web-interface`](skills/agent-web-interface/SKILL.md) skill can also be installed independently — without the MCP server — using [`npx skills`](https://github.com/vercel-labs/skills):
 
 ```bash
 npx skills add lespaceman/agent-web-interface
 ```
 
-This copies **only the skill** into your agent's `skills/` directory — it does not install the MCP server. Run the `claude mcp add agent-web-interface` command above as well so the `mcp__agent-web-interface__*` tools exist for the skill to call.
-
-### Use your existing Chrome session
-
-To reuse bookmarks, extensions, cookies, and logged-in sessions:
-
-```bash
-claude mcp add agent-web-interface \
-  -e AWI_BROWSER_MODE=user \
-  -- npx agent-web-interface@latest
-```
-
-This connects to your running Chrome when remote debugging is enabled.
-
-### Persistent browser profile
-
-To launch Chrome with a dedicated persistent profile:
-
-```bash
-claude mcp add agent-web-interface \
-  -e AWI_BROWSER_MODE=persistent \
-  -- npx agent-web-interface@latest
-```
-
-### Headless isolated browser
-
-```bash
-claude mcp add agent-web-interface \
-  -e AWI_BROWSER_MODE=isolated \
-  -e AWI_HEADLESS=true \
-  -- npx agent-web-interface@latest
-```
+This copies only the skill into your agent's `skills/` directory. You still need to register the MCP server separately (the `install` command above does both). `npx skills` is intentionally kept as a supported alternative for skill-only workflows — see [ADR-0003](docs/adr/0003-keep-npx-skills-alongside-installer.md).
 
 ---
 
-## Claude Desktop / Cursor / VS Code
+## Manual setup (Claude Desktop / Cursor / VS Code)
 
-Add the server to your MCP client configuration:
+If you prefer to edit config files manually, add the server under the appropriate key:
 
 ```json
 {
   "mcpServers": {
     "agent-web-interface": {
+      "command": "npx",
+      "args": ["agent-web-interface@latest"]
+    }
+  }
+}
+```
+
+VS Code uses `servers` instead of `mcpServers` and requires `"type": "stdio"`:
+
+```json
+{
+  "servers": {
+    "agent-web-interface": {
+      "type": "stdio",
       "command": "npx",
       "args": ["agent-web-interface@latest"]
     }

--- a/src/cli/dispatch.ts
+++ b/src/cli/dispatch.ts
@@ -23,9 +23,20 @@ export async function dispatch(argv: string[], deps?: DispatchDeps): Promise<Dis
     process.stderr.write(
       'Usage: agent-web-interface [command]\n\n' +
         'Commands:\n' +
-        '  install --harness <harness>   Register MCP server and place skill\n' +
+        '  install [flags]               Register MCP server and place skill\n' +
+        '  doctor                        Show per-harness installation status\n' +
         '\n' +
-        'Supported harnesses: claude-code\n' +
+        'Install flags:\n' +
+        '  --harness <id|all|csv>        claude-code, cursor, vscode, claude-desktop, all\n' +
+        '  --scope project|user          Config scope (default: project)\n' +
+        '  --global                      Alias for --scope global\n' +
+        '  --project                     Alias for --scope project\n' +
+        '  --browser-mode <mode>         auto (default), user, persistent, isolated\n' +
+        '  --headless                    Launch browser headless\n' +
+        '  --cdp-url <url>               Connect to existing Chrome DevTools endpoint\n' +
+        '  --pin <version>               Register exact version instead of @latest\n' +
+        '  --dry-run                     Preview changes without writing files\n' +
+        '  --yes, -y                     Skip interactive prompts\n' +
         '\n' +
         'Server mode (default, no command):\n' +
         '  --transport stdio|http        Transport mode (default: stdio)\n' +


### PR DESCRIPTION
## Summary

- Promotes `npx agent-web-interface install` as the canonical setup path in the README Quickstart section
- Demotes the manual two-step (`claude mcp add` + `npx skills add`) to an advanced/manual section
- Documents `npx skills add` as a kept-on-purpose skill-only alternative with a link to ADR-0003
- Documents all install flags: `--harness`, `--scope`, `--global`, `--project`, `--browser-mode`, `--headless`, `--cdp-url`, `--pin`, `--dry-run`, `--yes`
- Documents the `agent-web-interface doctor` command
- Documents VS Code's `servers` key / `type: "stdio"` difference from `mcpServers`
- Updates `--help` text in dispatch.ts to include all flags and the doctor command
- Adds CHANGELOG entry covering the full install/doctor/adapter feature surface

## Test plan

- [x] `npm run check` green (88 files, 1847 tests)
- [x] No new code changes — docs and help text only

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)