### PR TITLE
fix(install): clean up interactive summary UX and repair three bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,28 @@
+## [4.6.3] - 2026-06-07
+
+- docs: update README quickstart to lead with install command + CHANGELOG (#83)
+- Merge pull request #82 from lespaceman/feat/doctor-command
+- feat: add doctor command — read-only per-harness status (#70)
+- Merge pull request #81 from lespaceman/feat/interactive-install
+- feat: interactive install flow + flag surface + adapter registry (#69)
+- Merge pull request #80 from lespaceman/feat/claude-desktop-adapter
+- feat: add ClaudeDesktopAdapter (global, OS-specific paths, MCP-only) (#68)
+- Merge pull request #79 from lespaceman/feat/vscode-adapter
+- feat: add VSCodeAdapter for servers/type:stdio MCP + instructions (#72)
+- Merge pull request #78 from lespaceman/feat/cursor-adapter
+- feat: add CursorAdapter for MCP + .mdc rule placement (#71)
+- Merge pull request #77 from lespaceman/feat/skill-packaging
+- feat(#67): portable skill packaging + Claude Code skill placement
+- Merge pull request #76 from lespaceman/feat/config-io
+- feat(#66): config-io + HarnessAdapter interface + Claude Code .mcp.json fallback
+- Merge pull request #75 from lespaceman/feat/install-dispatch
+- feat(#64): install dispatch + Claude Code MCP registration
+- Merge pull request #74 from lespaceman/docs/install-design-docs
+- docs: add install design docs (ADR-0002, ADR-0003, CONTEXT.md glossary)
+- docs: add project context, ADR-0001, captcha findings, and non-DOM interaction PRD (#63)
+- chore(skills): commit portable skills-lock.json, ignore .agents install dir (#62)
+- chore(skill): optimize agent-web-interface description for triggering (#61)
+
 ## [Unreleased]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "agent-web-interface",
-  "version": "4.6.2",
+  "version": "4.6.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "agent-web-interface",
-      "version": "4.6.2",
+      "version": "4.6.3",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^1.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agent-web-interface",
-  "version": "4.6.2",
+  "version": "4.6.3",
   "description": "MCP server for AI-powered browser automation with semantic page snapshots",
   "type": "module",
   "main": "dist/src/index.js",

--- a/src/install/config-io.ts
+++ b/src/install/config-io.ts
@@ -56,12 +56,25 @@ export async function writeFileAtomic(
   const dir = dirname(path);
   await mkdir(dir, { recursive: true });
 
-  // Backup pre-existing file
+  let hasExistingFile = false;
   try {
-    await stat(path);
-    await copyFile(path, path + '.bak');
+    const existing = await readFile(path, 'utf-8');
+    if (existing === content) {
+      return { changed: false, dryRun: false };
+    }
+    hasExistingFile = true;
   } catch {
-    // File does not exist — no backup needed
+    // File does not exist or cannot be read — proceed with the atomic write.
+  }
+
+  // Backup pre-existing file
+  if (hasExistingFile) {
+    try {
+      await stat(path);
+      await copyFile(path, path + '.bak');
+    } catch {
+      // File disappeared between read and backup — no backup needed.
+    }
   }
 
   // Atomic write: temp file → rename

--- a/src/install/harness/claude-code.ts
+++ b/src/install/harness/claude-code.ts
@@ -29,7 +29,7 @@ const SERVER_COMMAND: ServerCommand = {
 function makeDefaultRunner(): CommandRunner {
   return (cmd, args) =>
     new Promise((resolve, reject) => {
-      const child = spawn(cmd, args, { stdio: 'inherit' });
+      const child = spawn(cmd, args, { stdio: 'ignore' });
       child.on('close', (code) => resolve(code ?? 0));
       child.on('error', reject);
     });
@@ -67,35 +67,37 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
   async apply(opts: ApplyOpts): Promise<ApplyResult> {
     const { dryRun = false, cwd = process.cwd(), resolvedCommand = SERVER_COMMAND } = opts;
 
+    const scopeFlag = opts.scope === 'user' ? 'user' : 'project';
     const mcpAddArgs = [
       'mcp',
       'add',
+      '-s',
+      scopeFlag,
       SERVER_NAME,
+      '--',
       resolvedCommand.command,
       ...resolvedCommand.args,
     ];
 
-    // Try claude mcp add first
-    let claudeAbsent = false;
-    try {
-      const exitCode = await this.run('claude', mcpAddArgs);
-      if (exitCode !== 0) {
-        throw new Error(`claude mcp add exited with code ${exitCode}`);
+    // Try `claude mcp add`; skip on dry-run (real CLI mutation must not fire).
+    // Fall through to .mcp.json on any failure (e.g. server already registered,
+    // claude CLI absent).
+    if (!dryRun) {
+      try {
+        const exitCode = await this.run('claude', mcpAddArgs);
+        if (exitCode === 0) {
+          await this.placeSkill(cwd, dryRun);
+          return {
+            changed: true,
+            dryRun: false,
+            message: 'Registered via `claude mcp add`',
+          };
+        }
+        // Non-zero exit (e.g. already registered): fall through to .mcp.json
+      } catch (err) {
+        if (!isNotFound(err)) throw err;
+        // ENOENT — claude not installed: fall through to .mcp.json
       }
-      await this.placeSkill(cwd, dryRun);
-      return {
-        changed: true,
-        dryRun: false,
-        message: '✓ Registered in Claude Code via `claude mcp add`',
-      };
-    } catch (err) {
-      if (!isNotFound(err)) throw err;
-      claudeAbsent = true;
-    }
-
-    if (!claudeAbsent) {
-      // unreachable — satisfies type narrowing
-      throw new Error('unexpected state');
     }
 
     // Fallback: write .mcp.json
@@ -107,6 +109,7 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
     });
 
     if (!changed) {
+      await this.placeSkill(cwd, dryRun);
       return {
         changed: false,
         dryRun,
@@ -119,9 +122,7 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
     return {
       changed: result.changed,
       dryRun: result.dryRun,
-      message: dryRun
-        ? 'Would write .mcp.json (--dry-run)'
-        : '✓ Registered in Claude Code via .mcp.json',
+      message: dryRun ? 'Would write .mcp.json (--dry-run)' : 'Registered via .mcp.json',
     };
   }
 

--- a/src/install/harness/claude-code.ts
+++ b/src/install/harness/claude-code.ts
@@ -8,7 +8,13 @@ import type {
   HarnessStatus,
   ServerCommand,
 } from '../harness-adapter.js';
-import { readJsonConfig, mergeAtPath, writeJsonAtomic, writeFileAtomic } from '../config-io.js';
+import {
+  readJsonConfig,
+  mergeAtPath,
+  writeJsonAtomic,
+  writeFileAtomic,
+  type WriteResult,
+} from '../config-io.js';
 import { resolveSkill } from '../skill-source.js';
 
 export type CommandRunner = (cmd: string, args: string[]) => Promise<number>;
@@ -93,9 +99,15 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
             message: 'Registered via `claude mcp add`',
           };
         }
-        // Non-zero exit (e.g. already registered): fall through to .mcp.json
+        if (scopeFlag !== 'project') {
+          throw new Error(`claude mcp add exited with code ${exitCode}`);
+        }
+        // Non-zero project-scope exit (e.g. already registered): fall through to .mcp.json
       } catch (err) {
         if (!isNotFound(err)) throw err;
+        if (scopeFlag !== 'project') {
+          throw err;
+        }
         // ENOENT — claude not installed: fall through to .mcp.json
       }
     }
@@ -109,11 +121,15 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
     });
 
     if (!changed) {
-      await this.placeSkill(cwd, dryRun);
+      const skillResult = await this.placeSkill(cwd, dryRun);
       return {
-        changed: false,
-        dryRun,
-        message: 'Already configured in .mcp.json (no changes needed)',
+        changed: skillResult.changed,
+        dryRun: dryRun || skillResult.dryRun,
+        message: skillResult.changed
+          ? dryRun
+            ? 'Already configured in .mcp.json; would repair Claude Code skill (--dry-run)'
+            : 'Already configured in .mcp.json; repaired Claude Code skill'
+          : 'Already configured in .mcp.json (no changes needed)',
       };
     }
 
@@ -126,13 +142,14 @@ export class ClaudeCodeAdapter implements HarnessAdapter {
     };
   }
 
-  private async placeSkill(cwd: string, dryRun: boolean): Promise<void> {
+  private async placeSkill(cwd: string, dryRun: boolean): Promise<WriteResult> {
     try {
       const skill = await this.resolveSkillFn();
       const skillPath = join(cwd, '.claude', 'skills', SERVER_NAME, 'SKILL.md');
-      await writeFileAtomic(skillPath, skill.rawContent, { dryRun });
+      return await writeFileAtomic(skillPath, skill.rawContent, { dryRun });
     } catch {
       // Skill placement is best-effort; never fails install
+      return { changed: false, dryRun };
     }
   }
 

--- a/src/install/harness/claude-desktop.ts
+++ b/src/install/harness/claude-desktop.ts
@@ -91,7 +91,7 @@ export class ClaudeDesktopAdapter implements HarnessAdapter {
       dryRun: writeResult.dryRun,
       message: dryRun
         ? 'Would write claude_desktop_config.json (--dry-run)'
-        : '✓ Registered in Claude Desktop via claude_desktop_config.json\n  Note: skill placement not supported for Claude Desktop',
+        : 'Registered via claude_desktop_config.json',
     };
   }
 

--- a/src/install/index.ts
+++ b/src/install/index.ts
@@ -28,10 +28,31 @@ function printSummaryTable(results: HarnessResult[]): void {
       process.stderr.write(`  ${label}  ✗ ${error}\n`);
     } else if (result) {
       const status = result.dryRun ? `(dry-run) ${result.message}` : result.message;
-      process.stderr.write(`  ${label}  ${status}\n`);
+      const skillNote = !adapter.supportsSkill ? ' (no skill placement)' : '';
+      process.stderr.write(`  ${label}  ${status}${skillNote}\n`);
     }
   }
   process.stderr.write('\n');
+}
+
+async function printClackSummary(results: HarnessResult[]): Promise<boolean> {
+  const { log, outro } = await import('@clack/prompts');
+  for (const { adapter, result, error } of results) {
+    if (error) {
+      log.error(`${adapter.label}: ${error}`);
+    } else if (result) {
+      const msg = result.dryRun ? `(dry-run) ${result.message}` : result.message;
+      const skillNote = !adapter.supportsSkill ? ' · no skill placement' : '';
+      if (result.changed && !result.dryRun) {
+        log.success(`${adapter.label}: ${msg}${skillNote}`);
+      } else {
+        log.info(`${adapter.label}: ${msg}${skillNote}`);
+      }
+    }
+  }
+  const anyFailed = results.some((r) => r.error != null);
+  outro(anyFailed ? 'Done (with errors — see above).' : 'All done!');
+  return anyFailed;
 }
 
 async function applyAdapters(
@@ -108,7 +129,6 @@ export async function runInstall(argv: string[], deps: InstallDeps = {}): Promis
     { ...flags, browserMode: choices.browserMode, scope: choices.scope },
     deps
   );
-  printSummaryTable(results);
-  const anyFailed = results.some((r) => r.error != null);
+  const anyFailed = await printClackSummary(results);
   if (anyFailed) process.exit(1);
 }

--- a/tests/unit/install/config-io.test.ts
+++ b/tests/unit/install/config-io.test.ts
@@ -110,6 +110,21 @@ describe('writeJsonAtomic', () => {
     }
   });
 
+  it('does not rewrite or back up identical file content', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const path = join(dir, 'config.json');
+      await writeFile(path, JSON.stringify({ foo: 'bar' }, null, 2) + '\n');
+
+      const result = await writeJsonAtomic(path, { foo: 'bar' });
+
+      expect(result.changed).toBe(false);
+      await expect(stat(path + '.bak')).rejects.toThrow();
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
   it('dry-run reports the change but writes nothing', async () => {
     const dir = await makeTmpDir();
     try {

--- a/tests/unit/install/harness/claude-code.test.ts
+++ b/tests/unit/install/harness/claude-code.test.ts
@@ -67,6 +67,23 @@ describe('ClaudeCodeAdapter.apply()', () => {
     }
   });
 
+  it('does not fall back to project .mcp.json when user-scope claude mcp add fails', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const runner: CommandRunner = () => Promise.resolve(1);
+      const adapter = new ClaudeCodeAdapter({ runner });
+
+      await expect(adapter.apply({ scope: 'user', cwd: dir })).rejects.toThrow(
+        /claude mcp add exited with code 1/i
+      );
+
+      const { stat } = await import('node:fs/promises');
+      await expect(stat(join(dir, '.mcp.json'))).rejects.toThrow();
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
   it('falls back to .mcp.json when claude CLI is not found (ENOENT)', async () => {
     const dir = await makeTmpDir();
     try {
@@ -233,15 +250,36 @@ describe('ClaudeCodeAdapter skill placement', () => {
       const { rm } = await import('node:fs/promises');
       await rm(join(dir, '.claude', 'skills', 'agent-web-interface', 'SKILL.md'));
 
-      // Second apply: .mcp.json unchanged (changed=false) but skill should be re-placed
+      // Second apply: .mcp.json unchanged but skill should be re-placed and reported.
       const second = await adapter.apply({ scope: 'project', cwd: dir });
-      expect(second.changed).toBe(false);
+      expect(second.changed).toBe(true);
+      expect(second.message).toContain('repaired Claude Code skill');
 
       const content = await readFile(
         join(dir, '.claude', 'skills', 'agent-web-interface', 'SKILL.md'),
         'utf-8'
       );
       expect(content).toBe(FAKE_SKILL);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('does not report a change when .mcp.json and SKILL.md are both current', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const runner: CommandRunner = () => {
+        const err = new Error('ENOENT') as NodeJS.ErrnoException;
+        err.code = 'ENOENT';
+        return Promise.reject(err);
+      };
+      const adapter = new ClaudeCodeAdapter({ runner, skillResolver });
+
+      await adapter.apply({ scope: 'project', cwd: dir });
+      const second = await adapter.apply({ scope: 'project', cwd: dir });
+
+      expect(second.changed).toBe(false);
+      expect(second.message).toContain('no changes needed');
     } finally {
       await cleanup(dir);
     }

--- a/tests/unit/install/harness/claude-code.test.ts
+++ b/tests/unit/install/harness/claude-code.test.ts
@@ -140,17 +140,25 @@ describe('ClaudeCodeAdapter.apply()', () => {
     }
   });
 
-  it('dry-run does not invoke claude mcp add', async () => {
-    const calls: [string, string[]][] = [];
-    const runner: CommandRunner = (cmd, args) => {
-      calls.push([cmd, args]);
-      return Promise.resolve(0);
-    };
-    const adapter = new ClaudeCodeAdapter({ runner });
+  it('dry-run does not invoke claude mcp add and does not write .mcp.json', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const calls: [string, string[]][] = [];
+      const runner: CommandRunner = (cmd, args) => {
+        calls.push([cmd, args]);
+        return Promise.resolve(0);
+      };
+      const adapter = new ClaudeCodeAdapter({ runner });
 
-    await adapter.apply({ scope: 'project', dryRun: true });
+      const result = await adapter.apply({ scope: 'project', cwd: dir, dryRun: true });
 
-    expect(calls).toHaveLength(0);
+      expect(calls).toHaveLength(0);
+      expect(result.dryRun).toBe(true);
+      const { stat } = await import('node:fs/promises');
+      await expect(stat(join(dir, '.mcp.json'))).rejects.toThrow();
+    } finally {
+      await cleanup(dir);
+    }
   });
 
   it('fallback respects --dry-run: writes nothing', async () => {

--- a/tests/unit/install/harness/claude-code.test.ts
+++ b/tests/unit/install/harness/claude-code.test.ts
@@ -34,7 +34,10 @@ describe('ClaudeCodeAdapter.apply()', () => {
     expect(args).toEqual([
       'mcp',
       'add',
+      '-s',
+      'project',
       'agent-web-interface',
+      '--',
       'npx',
       '-y',
       'agent-web-interface@latest',
@@ -43,11 +46,25 @@ describe('ClaudeCodeAdapter.apply()', () => {
     stderrSpy.mockRestore();
   });
 
-  it('throws when claude CLI returns non-zero exit code', async () => {
-    const runner: CommandRunner = () => Promise.resolve(2);
-    const adapter = new ClaudeCodeAdapter({ runner });
+  it('falls back to .mcp.json when claude CLI returns non-zero exit code', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const runner: CommandRunner = () => Promise.resolve(1);
+      const adapter = new ClaudeCodeAdapter({ runner });
 
-    await expect(adapter.apply({ scope: 'project' })).rejects.toThrow(/exit(ed)? with code 2/i);
+      const result = await adapter.apply({ scope: 'project', cwd: dir });
+
+      expect(result.changed).toBe(true);
+      const mcpJson = JSON.parse(await readFile(join(dir, '.mcp.json'), 'utf-8')) as {
+        mcpServers: Record<string, { command: string; args: string[] }>;
+      };
+      expect(mcpJson.mcpServers['agent-web-interface']).toEqual({
+        command: 'npx',
+        args: ['-y', 'agent-web-interface@latest'],
+      });
+    } finally {
+      await cleanup(dir);
+    }
   });
 
   it('falls back to .mcp.json when claude CLI is not found (ENOENT)', async () => {
@@ -123,6 +140,19 @@ describe('ClaudeCodeAdapter.apply()', () => {
     }
   });
 
+  it('dry-run does not invoke claude mcp add', async () => {
+    const calls: [string, string[]][] = [];
+    const runner: CommandRunner = (cmd, args) => {
+      calls.push([cmd, args]);
+      return Promise.resolve(0);
+    };
+    const adapter = new ClaudeCodeAdapter({ runner });
+
+    await adapter.apply({ scope: 'project', dryRun: true });
+
+    expect(calls).toHaveLength(0);
+  });
+
   it('fallback respects --dry-run: writes nothing', async () => {
     const dir = await makeTmpDir();
     try {
@@ -168,6 +198,36 @@ describe('ClaudeCodeAdapter skill placement', () => {
       const adapter = new ClaudeCodeAdapter({ runner, skillResolver });
 
       await adapter.apply({ scope: 'project', cwd: dir });
+
+      const content = await readFile(
+        join(dir, '.claude', 'skills', 'agent-web-interface', 'SKILL.md'),
+        'utf-8'
+      );
+      expect(content).toBe(FAKE_SKILL);
+    } finally {
+      await cleanup(dir);
+    }
+  });
+
+  it('places SKILL.md even when .mcp.json is already configured (repair path)', async () => {
+    const dir = await makeTmpDir();
+    try {
+      const runner: CommandRunner = () => {
+        const err = new Error('ENOENT') as NodeJS.ErrnoException;
+        err.code = 'ENOENT';
+        return Promise.reject(err);
+      };
+      const adapter = new ClaudeCodeAdapter({ runner, skillResolver });
+
+      // First apply writes .mcp.json + skill
+      await adapter.apply({ scope: 'project', cwd: dir });
+      // Delete skill to simulate partial prior install
+      const { rm } = await import('node:fs/promises');
+      await rm(join(dir, '.claude', 'skills', 'agent-web-interface', 'SKILL.md'));
+
+      // Second apply: .mcp.json unchanged (changed=false) but skill should be re-placed
+      const second = await adapter.apply({ scope: 'project', cwd: dir });
+      expect(second.changed).toBe(false);
 
       const content = await readFile(
         join(dir, '.claude', 'skills', 'agent-web-interface', 'SKILL.md'),


### PR DESCRIPTION
## Summary

- **Silence subprocess bleed** — `claude mcp add` runs with `stdio:'ignore'`; raw CLI output no longer interrupts the clack prompt flow
- **Fix `--dry-run` violation** — `claude mcp add` was running unconditionally even with `dryRun=true` and returning `dryRun: false`; now guarded behind `!dryRun`
- **Fix skill-placement gap** — the `.mcp.json` already-configured early-return path skipped `placeSkill`, so a partial prior install (config present, skill missing) was never repaired; now fixed
- **Fix scope and separator args** — adds `-s <scope>` and `--` to `claude mcp add` invocation so the `-y` npx flag isn't misinterpreted as a CLI flag
- **Fall through gracefully on non-zero exit** — instead of throwing, a failed `claude mcp add` (e.g. server already registered under another scope) silently falls back to writing `.mcp.json`
- **Clack-native summary** — interactive path now uses `log.success` / `log.info` / `log.error` + `outro`; `log.success` only fires on real changes (not dry-run, not already-configured)
- **Remove embedded newline from Claude Desktop message** — the `\n  Note: skill placement not supported` was breaking the summary table; now surfaced via a `· no skill placement` suffix in both formatters

## Test plan

- [ ] `npm run check` green (type-check + lint + format + 1849 tests)
- [ ] `node dist/src/index.js install` interactive flow shows clean clack output with no subprocess bleed
- [ ] Running install twice in a row does not error on second run
- [ ] `node dist/src/index.js install --dry-run` does not register anything (confirmed by new test: runner never called)
- [ ] After a partial install (config present, skill file deleted), re-running install repairs the skill file

🤖 Generated with [Claude Code](https://claude.com/claude-code)