### PR TITLE
refactor(#92): unify non-DOM surface detection (follow-up to #91)

### DIFF
--- a/docs/plans/2026-06-16-deepen-action-transaction-non-dom-detection.md
+++ b/docs/plans/2026-06-16-deepen-action-transaction-non-dom-detection.md
@@ -1,0 +1,201 @@
+# Deepen the Action Transaction: unify non-DOM surface detection
+
+Status: proposed
+Relates to: PR #91 (non-DOM surface model), architecture-review card "Deepen The Action Transaction"
+Supersedes the ad-hoc detection added in `src/tools/interaction-tools.ts`.
+
+## Why this exists
+
+PR #91 made dialogs, file pickers, and permission prompts perceivable as
+`<non_dom>` surfaces. The capability is correct, but it was bolted onto the
+click handler as **three serial, differently-shaped probes**. Three concrete
+defects fall out of that one structural gap:
+
+1. **Per-click latency floor (#1).** Every DOM click that does *not* open a
+   permission prompt still awaits `waitForPendingPermission` for the full
+   `PERMISSION_CLICK_RACE_TIMEOUT_MS = 500ms`
+   (`interaction-tools.ts:71`, `:332`, `:449`). The permission signal arrives
+   asynchronously over a CDP binding *after* the click resolves, and there is no
+   "nothing was requested" signal, so the code blind-polls. Result: a 500ms tax
+   on the most common action in the system.
+
+2. **Speculative CDP round-trips per click (#2).** For every `button` / `input` /
+   `text` click, `resolveFileInputTarget` runs `DOM.resolveNode` →
+   `Runtime.callFunctionOn` → `DOM.describeNode` (`interaction-tools.ts:602`) to
+   guess whether a file input is hiding nearby — three round-trips to learn
+   "no" ~99% of the time.
+
+3. **Orphaned safety net (#3).** `DialogManager.applyDefaultPolicy()`
+   (`dialog-manager.ts:173`) exists to auto-dismiss an unhandled dialog and
+   prevent session deadlock, but has **zero callers**. Nothing owns the surface
+   lifecycle, so nothing invokes the net.
+
+These are not three bugs. They are three symptoms of **the non-DOM channel
+having no unified signal and no owner**. Patching each in place (lower the
+timeout, cache the resolve, wire one call) leaves the structure that produced
+them. This plan removes the structure.
+
+## Root cause
+
+The three surfaces are all **events the browser emits as a side effect of an
+action**, and two of three already have native CDP events:
+
+| Surface     | Real signal today                                  | Blocks renderer? |
+| ----------- | -------------------------------------------------- | ---------------- |
+| Dialog      | `Page.javascriptDialogOpening` (event)             | **Yes**          |
+| File picker | `Page.fileChooserOpened` (event, interception on)  | No               |
+| Permission  | injected binding → `Runtime.bindingCalled` (event) | No               |
+
+All three are **event-driven**. Yet the click handler treats them as three
+unrelated questions asked in sequence — race-the-click for dialogs, a timestamp
+flag for choosers, a fixed poll for permissions. The poll exists only because
+permission detection was modeled as "ask after the click" instead of "observe
+during the wait the click already pays."
+
+Two facts the current code under-uses:
+
+- **Stabilization is already a wait window.** Every click already awaits
+  `stabilizeAfterAction` (`interaction-tools.ts:156`, `:475`) — network-idle +
+  DOM render, typically longer than the sub-100ms permission binding round-trip.
+  A permission requested by the click's handler will have fired *during* that
+  window. It can be read as a flag afterward for **zero added latency**, instead
+  of polled for beforehand.
+- **File-chooser interception already fires for indirect triggers.** With
+  `Page.setInterceptFileChooserDialog` enabled (`dialog-manager.ts:107`),
+  clicking a styled button, a `<label for>`, or a hidden input all emit
+  `Page.fileChooserOpened` with the real input's `backendNodeId`. The
+  speculative `resolveFileInputTarget` DOM walk is **redundant with an event we
+  already subscribe to**.
+
+## Target architecture
+
+Two seams, consistent with the review's "Action transaction module."
+
+### 1. `NonDomChannel` (per page) — one owner for all surfaces
+
+Collapses `DialogManager` + `PermissionDetector` + the free-floating
+`surface-store` functions behind one object that owns surface state **and**
+exposes a single signal.
+
+```
+class NonDomChannel {
+  // Event-driven: resolves the instant ANY detector fires; never polls.
+  surfaceSignal(opts?: { settleWindowMs?: number }): Promise<NonDomSurface | null>
+
+  getActiveSurface(): NonDomSurface | null
+  setActiveSurface(s: NonDomSurface): void
+  clear(): void
+
+  // The deadlock net — now with an owner AND a caller (see slice 3).
+  applyDefaultPolicy(): Promise<void>
+}
+```
+
+Internally each handler (`javascriptDialogOpening`, `fileChooserOpened`,
+`bindingCalled`) **settles the same pending promise**. There is one place that
+knows "a surface is open," instead of three booleans interrogated in order.
+
+### 2. The action transaction races action + signal, then reads flags
+
+The click lifecycle becomes a single shape:
+
+```
+1. race( clickAction , channel.surfaceSignal({ for blocking dialogs }) )
+     - a dialog blocks the renderer, so the click promise never settles while
+       it is open → the race lands on the dialog signal. (Unchanged, correct.)
+2. if dialog surface  → DO NOT stabilize (renderer blocked); return surface.
+3. else               → stabilizeAfterAction  (the wait we already pay)
+4. after stabilize, read channel for a non-blocking surface that fired during
+   the window: file-picker or permission. No extra poll, no extra round-trip.
+5. no surface → normal observe + snapshot + state response.
+```
+
+Latency on a no-surface click: **action + the stabilization it already did.**
+Zero added. The 500ms floor disappears because permission detection is a flag
+read on a window that already elapsed, not a serial wait.
+
+## Slices (tracer bullets)
+
+Ordered so each lands independently and the suite stays green. Matches the
+review's "First slice: DOM click plus non-DOM detection."
+
+### Slice 1 — Kill the permission poll; fold detection into stabilization (#1)
+
+- Remove `waitForPendingPermission` and `PERMISSION_CLICK_RACE_TIMEOUT_MS`.
+- Move the permission check to **after** `stabilizeAfterAction`, as a single
+  `permissionDetector.getPendingPermission()` flag read (the binding handler
+  already populates it during the window).
+- Keep the dialog race (`clickWithEarlyDialogDetection`) exactly as-is — it is
+  the correct primitive for a renderer-blocking surface.
+
+**Acceptance**
+- [ ] A click that opens no permission prompt adds **0ms** beyond stabilization
+      (assert with fake timers: no pending `setTimeout` after the click resolves
+      and stabilization completes).
+- [ ] A click that triggers `getUserMedia` / geolocation still surfaces
+      `<non_dom kind="permission">` (integration test against the manual page).
+- [ ] `grep` shows no remaining fixed-interval permission poll.
+
+### Slice 2 — Trust the interception event; delete speculative resolve (#2)
+
+- Delete the `resolveFileInputTarget`-on-every-click branch
+  (`interaction-tools.ts:602`).
+- Keep **only** the cheap direct-input fast path: when the clicked node's
+  snapshot attributes already say `input_type === 'file'`, build the picker
+  surface without dispatching a real click (no native picker, no CDP walk).
+- All indirect triggers (styled button, label, dropzone, hidden input) are
+  caught by `Page.fileChooserOpened` after the click — the same flag read added
+  in Slice 1, now covering choosers too.
+
+**Acceptance**
+- [ ] A plain button click issues **no** `DOM.resolveNode` / `DOM.describeNode`
+      (assert against the CDP mock call log).
+- [ ] Manual tests 1a–1e (direct, styled button, label, dropzone, multi) still
+      produce the file-picker surface.
+- [ ] Direct `input[type=file]` click still returns the surface without firing a
+      real picker.
+
+### Slice 3 — Give the safety net an owner and a caller (#3)
+
+- Move `applyDefaultPolicy` onto `NonDomChannel`.
+- Invoke it from the transaction when an agent issues a **page action while a
+  blocking dialog is pending** (i.e., they acted on the page instead of the
+  `nd-*` control) and on page-close / hard-navigation cleanup.
+
+**Acceptance**
+- [ ] A DOM action attempted while a dialog is pending auto-dismisses the dialog
+      (default policy) and returns a fresh state, rather than hanging.
+- [ ] `applyDefaultPolicy` has at least one production caller (no dead code).
+- [ ] Closing a page with a pending dialog does not leak a blocked renderer.
+
+### Slice 4 — Introduce `NonDomChannel`, retire the scattered accessors
+
+- Fold `DialogManager`, `PermissionDetector`, and the `getSurface/setSurface/
+  clearSurface` calls behind `NonDomChannel`. Detectors become private handlers
+  that settle the shared signal.
+- `interaction-tools` and `observation-tools` talk only to the channel.
+
+**Acceptance**
+- [ ] One `surfaceSignal()` race replaces the serial dialog/chooser/permission
+      branches in `clickElementWithNonDomDetection`.
+- [ ] `getOrCreateDialogManager` / `getOrCreatePermissionDetector` are no longer
+      called from tool handlers.
+- [ ] The lifecycle is tested at the channel seam; the old per-detector unit
+      tests that duplicated routing logic can retire.
+
+## Non-goals
+
+- No change to the **agent-facing contract**: `nd-*` eids, `<non_dom>` XML, and
+  the click/type resolution flow stay identical. This is an internal seam move.
+- No new surface kinds. Basic-auth / download-destination prompts are future
+  work and slot into `NonDomChannel` without re-touching the transaction.
+
+## Risk & validation
+
+- **Permission requested after stabilization completes** (timer-driven, not
+  click-driven) is intentionally *not* blocked on — it surfaces on the next
+  action or `snapshot`. This is correct: such a request is not an outcome of the
+  click being reported.
+- Validate end-to-end with `tests/manual/non-dom-channel.html` (all of upload,
+  dialog, permission allow/deny) plus a fake-timer unit asserting the no-surface
+  click pays no extra wait.

--- a/src/browser/session-manager.ts
+++ b/src/browser/session-manager.ts
@@ -1311,7 +1311,15 @@ export class SessionManager {
     page.on('close', () => {
       removeTracker(page);
       removeRecorder(page);
-      removeDialogManager(page);
+      // Apply the default auto-dismiss policy before tearing down the manager so a
+      // page that closes with a pending JavaScript dialog does not leak a blocked
+      // renderer. Best-effort and fire-and-forget — the page is going away.
+      void getOrCreateDialogManager(page)
+        .applyDefaultPolicy()
+        .catch(() => undefined)
+        .finally(() => {
+          removeDialogManager(page);
+        });
       removeDownloadManager(page);
       removePermissionDetector(page);
     });

--- a/src/tools/interaction-tools.ts
+++ b/src/tools/interaction-tools.ts
@@ -49,12 +49,7 @@ import { stabilizeAfterAction } from './action-stabilization.js';
 import { captureNavigationState } from './navigation-detection.js';
 import { ATTACHMENT_SIGNIFICANCE_THRESHOLD } from '../observation/observation.types.js';
 import { validateFilePaths, FileValidationError } from '../non-dom/file-path-validator.js';
-import {
-  resolveAndUploadFiles,
-  resolveFileInputTarget,
-  FileInputNotFoundError,
-  type FileInputTarget,
-} from '../non-dom/file-input-resolver.js';
+import { resolveAndUploadFiles } from '../non-dom/file-input-resolver.js';
 import type { PageHandle } from '../browser/page-registry.js';
 
 /** Configured allowed roots for file uploads. Empty = no restriction. */
@@ -559,27 +554,16 @@ export async function click(
     const node = ctx.resolveElementByEid(pageId, input.eid!, snap);
     const attrs = node.attributes as Record<string, unknown> | undefined;
 
-    let fileInputTarget: Pick<FileInputTarget, 'backendNodeId' | 'allowsMultiple'> | null = null;
+    // Direct file-input fast path: when the snapshot already says this node is an
+    // input[type=file], build the picker surface without dispatching a real click
+    // (no native picker, no CDP DOM walk). Indirect triggers — a styled button, a
+    // <label for>, a dropzone, a hidden input — are NOT probed speculatively here;
+    // they emit Page.fileChooserOpened on the real click and are caught by the
+    // wasFileChooserOpenedSince flag in clickElementWithNonDomDetection.
     if (attrs?.input_type === 'file') {
-      fileInputTarget = {
-        backendNodeId: node.backend_node_id,
-        allowsMultiple: (attrs?.multiple as boolean | undefined) !== undefined,
-      };
-    } else if (['button', 'input', 'text'].includes(node.kind)) {
-      try {
-        fileInputTarget = await resolveFileInputTarget(handleRef.current.cdp, node.backend_node_id);
-      } catch (err) {
-        if (!(err instanceof FileInputNotFoundError)) {
-          throw err;
-        }
-      }
-    }
-
-    // File input: return file-picker surface instead of native picker or guidance
-    if (fileInputTarget !== null) {
       const surface = buildFilePickerSurfaceForInput(
-        fileInputTarget.backendNodeId,
-        fileInputTarget.allowsMultiple
+        node.backend_node_id,
+        (attrs?.multiple as boolean | undefined) !== undefined
       );
       setSurface(handleRef.current.page, surface);
 

--- a/src/tools/interaction-tools.ts
+++ b/src/tools/interaction-tools.ts
@@ -63,12 +63,6 @@ const ALLOWED_ROOTS: string[] = process.env.UPLOAD_ALLOWED_ROOTS
   : [];
 
 const DIALOG_CLICK_RACE_TIMEOUT_MS = 1500;
-/**
- * Max time to wait after a click for an asynchronously-reported permission
- * request. Kept short: it is the latency a click pays when it does NOT trigger
- * a permission. The binding round-trip is typically well under 100ms.
- */
-const PERMISSION_CLICK_RACE_TIMEOUT_MS = 500;
 
 // ============================================================================
 // Non-DOM Click Handler
@@ -319,32 +313,6 @@ async function waitForPendingDialog(
   return false;
 }
 
-/**
- * Poll the permission detector for a request reported by the injected script.
- *
- * Unlike dialogs (a synchronous CDP event), a permission request is reported
- * asynchronously: the click runs page JS that calls a patched permission API,
- * which queries the current state and then notifies the host over a CDP
- * binding. That round-trip lands shortly *after* the click action resolves, so
- * we poll briefly. The wait is bounded and returns the instant a request
- * appears, so clicks that trigger no permission pay at most the short timeout.
- */
-async function waitForPendingPermission(
-  detector: ReturnType<typeof getOrCreatePermissionDetector>,
-  timeoutMs = PERMISSION_CLICK_RACE_TIMEOUT_MS
-): Promise<ReturnType<typeof detector.getPendingPermission>> {
-  const existing = detector.getPendingPermission();
-  if (existing) return existing;
-
-  const deadline = Date.now() + timeoutMs;
-  while (Date.now() < deadline) {
-    await new Promise((resolve) => setTimeout(resolve, 20));
-    const pending = detector.getPendingPermission();
-    if (pending) return pending;
-  }
-  return null;
-}
-
 async function clickWithEarlyDialogDetection(
   clickAction: () => Promise<void>,
   dialogManager: ReturnType<typeof getOrCreateDialogManager>
@@ -442,11 +410,15 @@ async function clickElementWithNonDomDetection(
     return stateXml + '\n' + renderNonDomSurface(surface);
   }
 
-  // 3. Permission request intercepted? Reported asynchronously by the injected
-  //    detector script over a CDP binding, so poll briefly. Unlike dialogs, a
-  //    permission prompt does not block the renderer, so recapture is safe.
+  // 3. Stabilization is the wait window the click already pays (network-idle +
+  //    DOM render). A permission requested by the click's handler fires over the
+  //    CDP binding *during* this window, so we stabilize first and then read the
+  //    flag — zero added latency, no fixed-interval poll. A permission prompt
+  //    does not block the renderer, so recapture afterward is safe.
   const permissionDetector = getOrCreatePermissionDetector(handle.page);
-  const pendingPermission = await waitForPendingPermission(permissionDetector);
+  await stabilizeAfterAction(handle.page);
+
+  const pendingPermission = permissionDetector.getPendingPermission();
   if (pendingPermission) {
     const surface = buildPermissionSurface(
       pendingPermission.permissions,
@@ -455,7 +427,6 @@ async function clickElementWithNonDomDetection(
     );
     setSurface(handle.page, surface);
 
-    await stabilizeAfterAction(handle.page);
     const captureResult = await captureSnapshot();
     ctx.getSnapshotStore().store(pageId, captureResult.snapshot);
     const stateManager = ctx.getStateManager(pageId);
@@ -465,15 +436,12 @@ async function clickElementWithNonDomDetection(
 
   if (!clickSucceeded) {
     // click failed and no non-DOM surface opened — capture best-effort state
-    await stabilizeAfterAction(handle.page);
     const captureResult = await captureSnapshot();
     ctx.getSnapshotStore().store(pageId, captureResult.snapshot);
     return ctx.getStateManager(pageId).generateResponse(captureResult.snapshot);
   }
 
   // === Normal DOM Click Flow ===
-  await stabilizeAfterAction(handle.page);
-
   const observations = await ctx
     .getObservationAccumulator()
     .getObservations(handle.page, actionStartTime);

--- a/src/tools/interaction-tools.ts
+++ b/src/tools/interaction-tools.ts
@@ -293,6 +293,36 @@ function toError(err: unknown): Error {
   return err instanceof Error ? err : new Error(String(err));
 }
 
+/**
+ * Safety net for the renderer-blocking dialog.
+ *
+ * A pending JavaScript dialog blocks the renderer, so any DOM action the agent
+ * issues against the page (instead of resolving the `nd-*` dialog control) would
+ * hang waiting on a thread that cannot run. When that happens we apply the
+ * DialogManager's default auto-dismiss policy, clear the stale surface, and
+ * return a fresh state response so the session keeps moving rather than
+ * deadlocking.
+ *
+ * Returns the state-response string when a dialog was dismissed (the caller
+ * should return it directly), or `null` when no dialog was pending (proceed with
+ * the normal DOM action).
+ */
+async function dismissBlockingDialogIfPending(
+  handle: PageHandle,
+  pageId: string,
+  ctx: ToolContext,
+  captureSnapshot: CaptureSnapshotFn
+): Promise<string | null> {
+  const dialogManager = getOrCreateDialogManager(handle.page);
+  if (!dialogManager.getPendingDialog()) return null;
+
+  // Auto-dismiss to unblock the renderer (default policy = dismiss).
+  await dialogManager.applyDefaultPolicy();
+  clearSurface(handle.page);
+
+  return afterNonDomResolution(handle, pageId, ctx, captureSnapshot);
+}
+
 async function waitForPendingDialog(
   dialogManager: ReturnType<typeof getOrCreateDialogManager>,
   timeoutMs = DIALOG_CLICK_RACE_TIMEOUT_MS
@@ -548,6 +578,16 @@ export async function click(
 
   const { handleRef, pageId, captureSnapshot } = await prepareActionContext(input.page_id, ctx);
 
+  // Safety net: if a blocking dialog is pending and the agent acted on the page
+  // (a real eid/coords) instead of the nd-* dialog control, auto-dismiss it.
+  const dismissed = await dismissBlockingDialogIfPending(
+    handleRef.current,
+    pageId,
+    ctx,
+    captureSnapshot
+  );
+  if (dismissed !== null) return dismissed;
+
   if (hasEid) {
     // DOM element click
     const snap = ctx.requireSnapshot(pageId);
@@ -622,6 +662,14 @@ export async function type(
 
   const { handleRef, pageId, captureSnapshot } = await prepareActionContext(input.page_id, ctx);
 
+  const dismissed = await dismissBlockingDialogIfPending(
+    handleRef.current,
+    pageId,
+    ctx,
+    captureSnapshot
+  );
+  if (dismissed !== null) return dismissed;
+
   // Normal DOM type
   const snap = ctx.requireSnapshot(pageId);
   const node = ctx.resolveElementByEid(pageId, input.eid, snap);
@@ -653,6 +701,14 @@ export async function press(
   const input = PressInputSchema.parse(rawInput);
   const { handleRef, pageId, captureSnapshot } = await prepareActionContext(input.page_id, ctx);
 
+  const dismissed = await dismissBlockingDialogIfPending(
+    handleRef.current,
+    pageId,
+    ctx,
+    captureSnapshot
+  );
+  if (dismissed !== null) return dismissed;
+
   const result = await executeAction(
     handleRef.current,
     async () => {
@@ -675,6 +731,14 @@ export async function select(
 ): Promise<import('./tool-schemas.js').SelectOutput> {
   const input = SelectInputSchema.parse(rawInput);
   const { handleRef, pageId, captureSnapshot } = await prepareActionContext(input.page_id, ctx);
+
+  const dismissed = await dismissBlockingDialogIfPending(
+    handleRef.current,
+    pageId,
+    ctx,
+    captureSnapshot
+  );
+  if (dismissed !== null) return dismissed;
 
   const snap = ctx.requireSnapshot(pageId);
   const node = ctx.resolveElementByEid(pageId, input.eid, snap);
@@ -703,6 +767,14 @@ export async function hover(
 ): Promise<import('./tool-schemas.js').HoverOutput> {
   const input = HoverInputSchema.parse(rawInput);
   const { handleRef, pageId, captureSnapshot } = await prepareActionContext(input.page_id, ctx);
+
+  const dismissed = await dismissBlockingDialogIfPending(
+    handleRef.current,
+    pageId,
+    ctx,
+    captureSnapshot
+  );
+  if (dismissed !== null) return dismissed;
 
   const snap = ctx.requireSnapshot(pageId);
   const node = ctx.resolveElementByEid(pageId, input.eid, snap);

--- a/tests/unit/non-dom/non-dom-interaction.test.ts
+++ b/tests/unit/non-dom/non-dom-interaction.test.ts
@@ -88,6 +88,7 @@ const {
     getFileChooserState: vi.fn().mockReturnValue({ opened: false, timestamp: 0 }),
     clearFileChooser: vi.fn(),
     resolveDialog: vi.fn().mockResolvedValue(undefined),
+    applyDefaultPolicy: vi.fn().mockResolvedValue(undefined),
   };
 
   const mockSnapshotStore = {
@@ -516,11 +517,18 @@ describe('click — DOM element: dialog detection post-click', () => {
   });
 
   it('detects a dialog after a DOM click and returns surface XML without stabilizing', async () => {
-    mockDialogManager.getPendingDialog.mockReturnValue({
-      type: 'alert',
+    // The dialog is opened BY this click, so it is not pending when the
+    // safety-net guard checks pre-click (1st call → null), only after (2nd+ → dialog).
+    const dialog = {
+      type: 'alert' as const,
       message: 'Hello',
       defaultValue: '',
       url: 'https://example.com',
+    };
+    let calls = 0;
+    mockDialogManager.getPendingDialog.mockImplementation(() => {
+      calls += 1;
+      return calls >= 2 ? dialog : null;
     });
 
     const result = await click({ page_id: 'test-page', eid: 'e1' }, ctx);
@@ -644,6 +652,61 @@ describe('click — DOM element: dialog detection post-click', () => {
       setTimeoutSpy.mockRestore();
       vi.useRealTimers();
     }
+  });
+});
+
+describe('DOM action while a dialog is already pending — safety net (Slice 3)', () => {
+  let ctx: ToolContext;
+  const pendingDialog = {
+    type: 'confirm' as const,
+    message: 'Are you sure?',
+    defaultValue: '',
+    url: 'https://example.com',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsNonDomEid.mockReturnValue(false);
+    mockGetSurface.mockReturnValue(null);
+    mockDialogManager.wasFileChooserOpenedSince.mockReturnValue(false);
+    mockPermissionDetector.getPendingPermission.mockReturnValue(null);
+    // Dialog is pending from a prior unresolved action — present from the first read.
+    mockDialogManager.getPendingDialog.mockReturnValue(pendingDialog);
+    mockDialogManager.applyDefaultPolicy.mockResolvedValue(undefined);
+    ctx = makeCtx();
+  });
+
+  it('click auto-dismisses the pending dialog instead of hanging, returns fresh state', async () => {
+    const result = await click({ page_id: 'test-page', eid: 'e1' }, ctx);
+
+    expect(mockDialogManager.applyDefaultPolicy).toHaveBeenCalledTimes(1);
+    expect(mockClearSurface).toHaveBeenCalled();
+    // Must NOT dispatch the DOM click onto a blocked renderer.
+    expect(mockClickByBackendNodeId).not.toHaveBeenCalled();
+    // Returns a fresh state response (afterNonDomResolution stabilizes + captures).
+    expect(mockStabilizeAfterAction).toHaveBeenCalled();
+    expect(result).toBeDefined();
+  });
+
+  it('type auto-dismisses the pending dialog before a DOM type', async () => {
+    mockIsNonDomEid.mockImplementation((eid: string) => eid.startsWith('nd-'));
+    const { executeActionWithRetry } = await import('../../../src/tools/execute-action.js');
+    vi.mocked(executeActionWithRetry).mockClear();
+
+    await type({ page_id: 'test-page', eid: 'dom-eid', text: 'hi' }, ctx);
+
+    expect(mockDialogManager.applyDefaultPolicy).toHaveBeenCalledTimes(1);
+    // Must not type into a blocked renderer.
+    expect(executeActionWithRetry).not.toHaveBeenCalled();
+  });
+
+  it('proceeds normally when no dialog is pending (guard is a no-op)', async () => {
+    mockDialogManager.getPendingDialog.mockReturnValue(null);
+
+    await click({ page_id: 'test-page', eid: 'e1' }, ctx);
+
+    expect(mockDialogManager.applyDefaultPolicy).not.toHaveBeenCalled();
+    expect(mockClickByBackendNodeId).toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/non-dom/non-dom-interaction.test.ts
+++ b/tests/unit/non-dom/non-dom-interaction.test.ts
@@ -602,6 +602,18 @@ describe('click — DOM element: dialog detection post-click', () => {
     expect(result).toBeDefined();
   });
 
+  it('issues no DOM.resolveNode / DOM.describeNode for a plain button click', async () => {
+    // Slice 2 acceptance: the speculative resolveFileInputTarget walk is gone. A
+    // plain (non-file) button click must not probe for a hidden file input via
+    // DOM.resolveNode / DOM.describeNode. Indirect file triggers are caught by
+    // the Page.fileChooserOpened interception flag, not a per-click CDP walk.
+    await click({ page_id: 'test-page', eid: 'e1' }, ctx);
+
+    const cdpMethods = mockHandle.cdp.send.mock.calls.map((c: unknown[]) => c[0]);
+    expect(cdpMethods).not.toContain('DOM.resolveNode');
+    expect(cdpMethods).not.toContain('DOM.describeNode');
+  });
+
   it('reads the permission flag once after stabilization (no fixed-interval poll)', async () => {
     // Slice 1 regression: permission detection must be a single flag read AFTER
     // stabilizeAfterAction, not a loop that polls getPendingPermission() on a timer.

--- a/tests/unit/non-dom/non-dom-interaction.test.ts
+++ b/tests/unit/non-dom/non-dom-interaction.test.ts
@@ -601,6 +601,38 @@ describe('click — DOM element: dialog detection post-click', () => {
     expect(mockClickByBackendNodeId).toHaveBeenCalledWith(mockHandle.cdp, 123, undefined);
     expect(result).toBeDefined();
   });
+
+  it('reads the permission flag once after stabilization (no fixed-interval poll)', async () => {
+    // Slice 1 regression: permission detection must be a single flag read AFTER
+    // stabilizeAfterAction, not a loop that polls getPendingPermission() on a timer.
+    mockPermissionDetector.getPendingPermission.mockReturnValue(null);
+
+    await click({ page_id: 'test-page', eid: 'e1' }, ctx);
+
+    // Exactly one read — the post-stabilization flag check — proves there is no poll loop.
+    expect(mockPermissionDetector.getPendingPermission).toHaveBeenCalledTimes(1);
+  });
+
+  it('a no-surface click schedules no permission-wait timers (fake timers)', async () => {
+    // Slice 1 acceptance: a click that opens no permission prompt adds 0ms beyond
+    // stabilization. With fake timers installed, the click must run to completion
+    // without scheduling the 20ms poll the removed waitForPendingPermission used.
+    vi.useFakeTimers();
+    const setTimeoutSpy = vi.spyOn(globalThis, 'setTimeout');
+    try {
+      mockPermissionDetector.getPendingPermission.mockReturnValue(null);
+
+      const promise = click({ page_id: 'test-page', eid: 'e1' }, ctx);
+      await vi.runAllTimersAsync();
+      await promise;
+
+      const pollCalls = setTimeoutSpy.mock.calls.filter(([, delay]) => delay === 20);
+      expect(pollCalls).toHaveLength(0);
+    } finally {
+      setTimeoutSpy.mockRestore();
+      vi.useRealTimers();
+    }
+  });
 });
 
 describe('click — file input: builds file-picker surface immediately', () => {


### PR DESCRIPTION
## Summary

Follow-up to #91 (merged). Three commits authored in a parallel worktree that landed **after** #91 was pushed, so they were not included in that PR's squash. They restructure the non-DOM surface detection added in #91 rather than adding new surfaces.

Plan: `docs/plans/2026-06-16-deepen-action-transaction-non-dom-detection.md` ("Deepen the Action Transaction: unify non-DOM surface detection").

## Motivation

#91 made dialogs, file pickers, and permission prompts perceivable as `<non_dom>` surfaces, but bolted detection onto the click handler as **three serial, differently-shaped probes**, producing three structural defects:

1. **Per-click latency floor** — every DOM click that opens no permission prompt still waited the full `PERMISSION_CLICK_RACE_TIMEOUT_MS = 500ms` for an async signal that may never come (this is the exact residual risk flagged in #91's review).
2. **Speculative CDP round-trips** — `resolveFileInputTarget` ran `DOM.resolveNode` → `Runtime.callFunctionOn` → `DOM.describeNode` on every button/input/text click to learn "no file input" ~99% of the time.
3. **Orphaned safety net** — `DialogManager.applyDefaultPolicy()` (auto-dismiss to prevent session deadlock) had zero callers.

## Changes

- **Slice 1** (`d098900`) — fold permission detection into the stabilization step (removes the blind 500ms poll on every click).
- **Slice 2** (`85fc9ea`) — trust file-chooser interception, drop the speculative `resolveFileInputTarget` round-trips.
- **Slice 3** (`9e821ef`) — give the dialog safety net an owner and a caller (wire `applyDefaultPolicy`).

Net: ~154 lines reworked in `src/tools/interaction-tools.ts`, plus `src/browser/session-manager.ts`, with expanded coverage in `tests/unit/non-dom/non-dom-interaction.test.ts`.

## Test plan

- [x] `npm run type-check` — clean
- [x] `npm test` — 96 files, **1983 tests** pass (6 new vs main's 1977)
- [ ] Reviewer: confirm no per-click latency regression and that the dialog safety-net path is exercised

> Note: the pre-existing `Security Audit` CI failure (transitive `ws`/`js-yaml` vulns) is tracked separately in #93 and is unrelated to this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
