### PR TITLE
chore(seo): npm metadata — site homepage, sharper keywords/description

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-web-interface",
   "version": "4.6.4",
-  "description": "MCP server for AI-powered browser automation with semantic page snapshots",
+  "description": "Token-efficient browser automation MCP for AI agents \u2014 semantic page snapshots and stable element IDs.",
   "type": "module",
   "main": "dist/src/index.js",
   "bin": {
@@ -27,11 +27,15 @@
   },
   "keywords": [
     "mcp",
+    "model-context-protocol",
     "browser-automation",
-    "cef",
-    "qt",
+    "ai-agents",
+    "puppeteer",
+    "llm",
+    "web-automation",
     "claude",
-    "ai-agents"
+    "semantic-dom",
+    "agent-tools"
   ],
   "author": "Nadeem",
   "license": "MIT",
@@ -42,7 +46,7 @@
   "bugs": {
     "url": "https://github.com/lespaceman/agent-web-interface/issues"
   },
-  "homepage": "https://github.com/lespaceman/agent-web-interface#readme",
+  "homepage": "https://agent-web-interface.com",
   "files": [
     "dist/**/*",
     "skills/**",


### PR DESCRIPTION
Off-page SEO checklist item §3 (npm package metadata). The landing repo's `docs/seo-offpage.md` flags these as belonging in the published package, not the landing repo.

**Changes to `package.json`:**
- `homepage` → `https://agent-web-interface.com` (was `.../agent-web-interface#readme`). npm surfaces this on the package page and it feeds npm search + Google's indexing of npmjs.com.
- `keywords` → dropped `cef`/`qt` (stale — the server is `puppeteer-core`/CDP-based, no CEF/Qt deps) and added `model-context-protocol`, `puppeteer`, `llm`, `web-automation`, `semantic-dom`, `agent-tools`.
- `description` → mirrors the site value prop (token-efficient semantic snapshots, stable element IDs).

No code or dependency changes. Ships on the next `npm publish`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)