### PR TITLE
chore: add minimal Dockerfile for Glama introspection

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Dockerfile for Glama (https://glama.ai/mcp/servers) build/inspection.
+#
+# Agent Web Interface is a stdio MCP server. Tools register at startup and Chrome
+# is launched lazily on the first tool call (see src/browser/ensure-browser.ts),
+# so `tools/list` introspection succeeds with no browser present — which is all
+# Glama's check requires.
+#
+# This image is intentionally minimal: it is for Glama's introspection check, not
+# for driving a real browser inside the container. Normal usage is local via
+# `npx agent-web-interface`, where the server connects to or launches the user's
+# Chrome. To run browser tools inside a container, install google-chrome-stable
+# and set AWI_BROWSER_MODE=isolated and AWI_HEADLESS=true.
+FROM node:20-slim
+
+RUN npm install -g agent-web-interface@latest
+
+ENTRYPOINT ["agent-web-interface"]


### PR DESCRIPTION
Adds a minimal `Dockerfile` so [Glama](https://glama.ai/mcp/servers) can build and run its introspection check on the server. Glama builds each listed server from a Dockerfile (maintainer-authored or AI-inferred) inside an isolated Firecracker microVM; passing the check makes the listing "installable / tested" and unblocks the merge-check on the [awesome-mcp-servers PR](https://github.com/punkpeye/awesome-mcp-servers/pull/9111).

**Why it's just Node, no browser:** the stdio server registers all tools and starts the transport *before* any browser launch — Chrome is created lazily on the first tool call (`src/browser/ensure-browser.ts`). Glama's check only needs the server to start and answer `tools/list`, so no Chrome is required in the image.

The header comment documents how to extend it (install `google-chrome-stable`, set `AWI_BROWSER_MODE=isolated` + `AWI_HEADLESS=true`) if you later want browser tools to run *inside* Glama's hosted runner rather than just passing the check.

Next step after merge: claim the listing on Glama and point its build at this Dockerfile (or let auto-detect pick it up), then Deploy → Make Release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)