### PR TITLE
fix(ci): prettier-format package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agent-web-interface",
   "version": "4.6.4",
-  "description": "Token-efficient browser automation MCP for AI agents \u2014 semantic page snapshots and stable element IDs.",
+  "description": "Token-efficient browser automation MCP for AI agents — semantic page snapshots and stable element IDs.",
   "type": "module",
   "main": "dist/src/index.js",
   "bin": {


### PR DESCRIPTION
`main` is red on the `format:check` step (`prettier --check`), which is blocking #97 and any new PR.

**Cause:** the metadata change in #96 was generated with a JSON serializer that escaped the em dash in `description` as `—`. That's valid JSON but Prettier normalizes it to the literal `—`, so `prettier --check` fails.

**Fix:** `prettier --write package.json` — a single-character change (`—` → `—`), no semantic change. `prettier --check` is clean afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)