### PR TITLE
docs: add website link near top of README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 Agent Web Interface is an MCP server that gives AI agents a compact, semantic interface to the browser.
 
+**[Website](https://agent-web-interface.com)** · **[npm](https://www.npmjs.com/package/agent-web-interface)** · **[vs. Playwright MCP](https://agent-web-interface.com/vs-playwright-mcp)**
+
 Instead of exposing the full DOM or accessibility tree, it returns structured page snapshots: visible regions, readable content, interactive elements, stable element IDs, form context, screenshots, canvas inspection, and network activity. Agents can then navigate and act on pages using semantic IDs instead of brittle selectors or massive context dumps.
 
 It is built for coding agents, browser agents, QA agents, research agents, and automation workflows that need reliable web interaction without wasting tokens on low-signal browser internals.


### PR DESCRIPTION
Adds a links line directly under the tagline so the **site is the first link** in the README — many MCP aggregators and crawlers scrape the first repository link as the canonical homepage (off-page SEO checklist §4).

`**[Website](https://agent-web-interface.com)** · **[npm](...)** · **[vs. Playwright MCP](...)**`

Docs-only, ships to npm on the next release (README is in the package `files` list).

🤖 Generated with [Claude Code](https://claude.com/claude-code)