### PR TITLE
chore: add glama.json to claim MCP server ownership on Glama

### DIFF
--- a/glama.json
+++ b/glama.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://glama.ai/mcp/schemas/server.json",
+  "maintainers": ["lespaceman"]
+}


### PR DESCRIPTION
## What

Adds a minimal `glama.json` at the repo root listing `lespaceman` as maintainer.

## Why

The server is hosted under the **lespaceman org**, not a personal account. Per [Glama's docs](https://glama.ai/blog/2025-07-08-what-is-glamajson), GitHub OAuth auto-claim only works for repos under a personal account — org-hosted servers **must** ship a `glama.json` with the maintainer's GitHub username to claim the listing. This complements the recent Glama introspection work (Dockerfile in #97).

## Contents

\`\`\`json
{
  "\$schema": "https://glama.ai/mcp/schemas/server.json",
  "maintainers": ["lespaceman"]
}
\`\`\`

## After merge

Re-run Glama's *Claim ownership* flow to trigger a re-sync of the new file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)